### PR TITLE
fix for Arduino version checking

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -136,7 +136,7 @@ uint8_t RTC_DS1307::begin(void) {
 }
 
 
-#if ARDUINO => 100
+#if ARDUINO >= 100
 
 
 uint8_t RTC_DS1307::isrunning(void) {


### PR DESCRIPTION
changed the logic for detecting version of Arduino used for build. Last version of this library expected 22 to be the last of the not 1.0 series. When 23 came out this library was broken.
