### PR TITLE
Using PROGMEM to reduce RAM usage

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -95,7 +95,7 @@ static uint8_t conv2d(const char* p) {
 
 // A convenient constructor for using "the compiler's time":
 //   DateTime now (__DATE__, __TIME__);
-// NOTE: using PSTR would further reduce the RAM footprint
+// NOTE: using F() would further reduce the RAM footprint, see below.
 DateTime::DateTime (const char* date, const char* time) {
     // sample input: date = "Dec 26 2009", time = "12:34:56"
     yOff = conv2d(date + 9);
@@ -114,6 +114,32 @@ DateTime::DateTime (const char* date, const char* time) {
     hh = conv2d(time);
     mm = conv2d(time + 3);
     ss = conv2d(time + 6);
+}
+
+// A convenient constructor for using "the compiler's time":
+// This version will save RAM by using PROGMEM to store it by using the F macro.
+//   DateTime now (F(__DATE__), F(__TIME__));
+DateTime::DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time) {
+    // sample input: date = "Dec 26 2009", time = "12:34:56"
+    char buff[11];
+    memcpy_P(buff, date, 11);
+    yOff = conv2d(buff + 9);
+    // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+    switch (buff[0]) {
+        case 'J': m = buff[1] == 'a' ? 1 : m = buff[2] == 'n' ? 6 : 7; break;
+        case 'F': m = 2; break;
+        case 'A': m = buff[2] == 'r' ? 4 : 8; break;
+        case 'M': m = buff[2] == 'r' ? 3 : 5; break;
+        case 'S': m = 9; break;
+        case 'O': m = 10; break;
+        case 'N': m = 11; break;
+        case 'D': m = 12; break;
+    }
+    d = conv2d(buff + 4);
+    memcpy_P(buff, time, 8);
+    hh = conv2d(buff);
+    mm = conv2d(buff + 3);
+    ss = conv2d(buff + 6);
 }
 
 uint8_t DateTime::dayOfWeek() const {    

--- a/RTClib.h
+++ b/RTClib.h
@@ -11,6 +11,7 @@ public:
     DateTime (uint16_t year, uint8_t month, uint8_t day,
                 uint8_t hour =0, uint8_t min =0, uint8_t sec =0);
     DateTime (const char* date, const char* time);
+    DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time);
     uint16_t year() const       { return 2000 + yOff; }
     uint8_t month() const       { return m; }
     uint8_t day() const         { return d; }

--- a/examples/ds1307/ds1307.pde
+++ b/examples/ds1307/ds1307.pde
@@ -17,7 +17,7 @@ void setup () {
   if (! rtc.isrunning()) {
     Serial.println("RTC is NOT running!");
     // following line sets the RTC to the date & time this sketch was compiled
-    rtc.adjust(DateTime(__DATE__, __TIME__));
+    rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
   }
 }
 

--- a/examples/softrtc/softrtc.pde
+++ b/examples/softrtc/softrtc.pde
@@ -8,7 +8,7 @@ RTC_Millis rtc;
 void setup () {
     Serial.begin(57600);
     // following line sets the RTC to the date & time this sketch was compiled
-    rtc.begin(DateTime(__DATE__, __TIME__));
+    rtc.begin(DateTime(F(__DATE__), F(__TIME__)));
 }
 
 void loop () {


### PR DESCRIPTION
This modification will allow you to easily store the
**DATE** and **TIME** strings in PROGMEM to stop them
from wasting SRAM.
It uses the __FlashStringHelper, which is the same as
what Serial.print() uses and is provided by default in
Arduino.
