### PR TITLE
Fix overflow in timespan constructor. Cast to int32_t is happening too late

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -214,6 +214,19 @@ TimeSpan TimeSpan::operator-(const TimeSpan& right) {
   return TimeSpan(_seconds-right._seconds);
 }
 
+void TimeSpan::set(int32_t seconds) {
+  _seconds = seconds;
+}
+
+void TimeSpan::set(int32_t days, int32_t hours, int32_t minutes, int32_t seconds) {
+  _seconds = (days*86400L + hours*3600 + minutes*60 + seconds);
+}
+
+void TimeSpan::set(const TimeSpan& copy) {
+  _seconds = copy._seconds;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // RTC_DS1307 implementation
 

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -198,7 +198,7 @@ TimeSpan::TimeSpan (int32_t seconds):
   _seconds(seconds)
 {}
 
-TimeSpan::TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds):
+TimeSpan::TimeSpan (int32_t days, int32_t hours, int32_t minutes, int32_t seconds):
   _seconds(days*86400L + hours*3600 + minutes*60 + seconds)
 {}
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -40,7 +40,7 @@ protected:
 class TimeSpan {
 public:
     TimeSpan (int32_t seconds = 0);
-    TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds);
+    TimeSpan (int32_t days, int32_t hours, int32_t minutes, int32_t seconds);
     TimeSpan (const TimeSpan& copy);
     int16_t days() const         { return _seconds / 86400L; }
     int8_t  hours() const        { return _seconds / 3600 % 24; }

--- a/RTClib.h
+++ b/RTClib.h
@@ -50,6 +50,10 @@ public:
 
     TimeSpan operator+(const TimeSpan& right);
     TimeSpan operator-(const TimeSpan& right);
+    
+    set(int32_t seconds);
+    set(int32_t days, int32_t hours, int32_t minutes, int32_t seconds);
+    set(const TimeSpan& copy);
 
 protected:
     int32_t _seconds;


### PR DESCRIPTION
The timespan object is exhibiting an overflow if hours>8 are used. This should not be the case and can be fixed by casting (defining) all input parameters to int32_t. This does not increase the memory usage, as the final result _seconds needs to be casted to int32_t anyway.