### PR TITLE
Add support for DS3231 in backwards-compatible way

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -12,13 +12,6 @@
  #define WIRE Wire1
 #endif
 
-#define DS1307_ADDRESS  0x68
-#define DS1307_CONTROL  0x07
-#define DS1307_NVRAM    0x08
-#define SECONDS_PER_DAY 86400L
-
-#define SECONDS_FROM_1970_TO_2000 946684800
-
 #if (ARDUINO >= 100)
  #include <Arduino.h> // capital A so it is error prone on case-sensitive filesystems
  // Macro to deal with the difference in I2C write functions from old and new Arduino versions.
@@ -265,11 +258,11 @@ DateTime RTC_DS1307::now() {
   return DateTime (y, m, d, hh, mm, ss);
 }
 
-Ds1307SqwPinMode RTC_DS1307::readSqwPinMode() {
+Ds1307SqwPinMode RTC_DS1307::readSqwPinMode(uint8_t control) {
   int mode;
 
   WIRE.beginTransmission(DS1307_ADDRESS);
-  WIRE._I2C_WRITE(DS1307_CONTROL);
+  WIRE._I2C_WRITE(control);
   WIRE.endTransmission();
   
   WIRE.requestFrom((uint8_t)DS1307_ADDRESS, (uint8_t)1);
@@ -279,9 +272,9 @@ Ds1307SqwPinMode RTC_DS1307::readSqwPinMode() {
   return static_cast<Ds1307SqwPinMode>(mode);
 }
 
-void RTC_DS1307::writeSqwPinMode(Ds1307SqwPinMode mode) {
+void RTC_DS1307::writeSqwPinMode(Ds1307SqwPinMode mode, uint8_t control) {
   WIRE.beginTransmission(DS1307_ADDRESS);
-  WIRE._I2C_WRITE(DS1307_CONTROL);
+  WIRE._I2C_WRITE(control);
   WIRE._I2C_WRITE(mode);
   WIRE.endTransmission();
 }

--- a/RTClib.h
+++ b/RTClib.h
@@ -4,6 +4,12 @@
 #ifndef _RTCLIB_H_
 #define _RTCLIB_H_
 
+#define DS1307_ADDRESS 0x68
+#define DS1307_CONTROL 0x07
+#define DS1307_NVRAM   0x08
+#define SECONDS_PER_DAY 86400L
+#define SECONDS_FROM_1970_TO_2000 946684800
+
 class TimeSpan;
 
 // Simple general-purpose date/time class (no TZ / DST / leap second handling!)
@@ -64,8 +70,8 @@ public:
     static void adjust(const DateTime& dt);
     uint8_t isrunning(void);
     static DateTime now();
-    static Ds1307SqwPinMode readSqwPinMode();
-    static void writeSqwPinMode(Ds1307SqwPinMode mode);
+    static Ds1307SqwPinMode readSqwPinMode(uint8_t control=DS1307_CONTROL);
+    static void writeSqwPinMode(Ds1307SqwPinMode mode, uint8_t control=DS1307_CONTROL);
     uint8_t readnvram(uint8_t address);
     void readnvram(uint8_t* buf, uint8_t size, uint8_t address);
     void writenvram(uint8_t address, uint8_t data);


### PR DESCRIPTION
By moving a few defines to the header file and adding an optional argument with default value to the square wave routines, this library can also support the DS3231. To use with DS3231, just pass 0x0E to the square wave routines and it will use that as the control register address. All existing DS1307 code is unaffected.
