### PR TITLE
Updated RTCMillis class

### DIFF
--- a/RTClib.h
+++ b/RTClib.h
@@ -74,15 +74,29 @@ public:
 };
 
 // RTC using the internal millis() clock, has to be initialized before use
-// NOTE: this clock won't be correct once the millis() timer rolls over (>49d?)
 class RTC_Millis {
 public:
-    static void begin(const DateTime& dt) { adjust(dt); }
-    static void adjust(const DateTime& dt);
-    static DateTime now();
-
+    void checkRollover();
+	
+    boolean begin(void);
+    void adjust(const DateTime& dt);
+    uint8_t isrunning(void) {return 1;};
+    DateTime now();
+    Ds1307SqwPinMode readSqwPinMode();
+    void writeSqwPinMode(Ds1307SqwPinMode mode) {};
+    uint8_t readnvram(uint8_t address) {};
+    void readnvram(uint8_t* buf, uint8_t size, uint8_t address) {};
+    void writenvram(uint8_t address, uint8_t data) {};
+    void writenvram(uint8_t address, uint8_t* buf, uint8_t size) {};
+	
 protected:
-    static long offset;
+    long offset;
+// Support for millis rollover:
+// 1. Periodically compare current millis() with previosly captured millis
+// 2. When previus millis is greater than current, a rollover count is increased
+// 3. In calculating now(), use additional count of 2^32/1000 to compensate for rollovers
+    unsigned long prevMillis;
+    unsigned int  countRollovers;
 };
 
 #endif // _RTCLIB_H_

--- a/examples/softrtc/softrtc.ino
+++ b/examples/softrtc/softrtc.ino
@@ -13,7 +13,7 @@ RTC_Millis rtc;
 void setup () {
     Serial.begin(57600);
     // following line sets the RTC to the date & time this sketch was compiled
-    rtc.begin(DateTime(F(__DATE__), F(__TIME__)));
+    rtc.begin();
     // This line sets the RTC with an explicit date & time, for example to set
     // January 21, 2014 at 3am you would call:
     // rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,6 +30,7 @@ isrunning	KEYWORD2
 now	KEYWORD2
 readSqwPinMode	KEYWORD2
 writeSqwPinMode	KEYWORD2
+checkRollover	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RTClib
-version=1.1.0
+version=1.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=A fork of Jeelab's fantastic RTC library


### PR DESCRIPTION
- exact same interface between RTC_DS1307 and RTCMillis classes, so only initial declaration would vary, the rest of the code could remain the same:
  # ifndef _USERTCMILLIS_
  
  RTC_DS1307 rtc; 
  # else
  
  RTC_Millis rtc;
  # endif
- millis() rollover fix so RTCMillis could be used for over 43 days.
