### PR TITLE
Make RTC_Millis immune to millis() rollover events

### DIFF
--- a/RTClib.h
+++ b/RTClib.h
@@ -121,7 +121,7 @@ public:
 };
 
 // RTC using the internal millis() clock, has to be initialized before use
-// NOTE: this clock won't be correct once the millis() timer rolls over (>49d?)
+// NOTE: this is immune to millis() rollover events
 class RTC_Millis {
 public:
     static void begin(const DateTime& dt) { adjust(dt); }
@@ -129,7 +129,8 @@ public:
     static DateTime now();
 
 protected:
-    static long offset;
+    static uint32_t lastUnix;
+    static uint32_t lastMillis;
 };
 
 #endif // _RTCLIB_H_


### PR DESCRIPTION
Every 49.7&nbsp;days (2<sup>32</sup>&nbsp;ms), `millis()` rolls over to zero. When this happens, the `RTC_Millis` “soft RTC” jumps back in time by 49.7&nbsp;days.

This pull request fixes the issue, provided that `RTC_Millis::now()` is called more often than the rollover period. The code relies on the fact that, owing to the rules of [modular arithmetic][], computing `millis() - lastMillis` [is rollover safe][safe].

Here is a test sketch coercing `millis()` to roll over early:

```c++
#include <Wire.h>
#include <RTClib.h>

void setup() {
    extern unsigned long timer0_millis;
    timer0_millis = -1500;  // 1.5 seconds before rollover
    RTC_Millis::begin(DateTime(__DATE__, __TIME__));
    Serial.begin(9600);
    Serial.println(" millis()    RTC_Millis::now()");
    Serial.println("-------------------------------");
}

void loop() {
    char buffer[48];
    DateTime t = RTC_Millis::now();
    sprintf(buffer, "%10lu  %04d-%02d-%02d %02d:%02d:%02d", millis(),
        t.year(), t.month(), t.day(), t.hour(), t.minute(), t.second());
    Serial.println(buffer);
    delay(1000);
}
```

The output produced by an Arduino Uno, without this fix:

```text
 millis()    RTC_Millis::now()
-------------------------------
4294965796  2018-06-05 20:51:09
4294966830  2018-06-05 20:51:10
       535  2018-04-17 03:48:24
      1536  2018-04-17 03:48:25
```

And the output with the fix applied:

```text
 millis()    RTC_Millis::now()
-------------------------------
4294965796  2018-06-05 20:51:27
4294966830  2018-06-05 20:51:28
       534  2018-06-05 20:51:29
      1536  2018-06-05 20:51:30
```

As a side effect of the changed algorithm, the “soft RTC” can now be set with sub-second resolution: once the time is set with `adjust()`, it will not change until a full second has elapsed. In a sense, the “implicit milliseconds field” of the time is cleared by `adjust()`, whereas in the current master branch it is always `millis()%1000`.

I am aware that this rollover issue has been addressed by pull request #55. However, the pull request I am submitting here is more efficient (fewer changes in the code, lower CPU and RAM usage) and more focused on this particular issue.

[modular arithmetic]: https://en.wikipedia.org/wiki/Modular_arithmetic
[safe]: https://arduino.stackexchange.com/a/12588/7508