### PR TITLE
Saner default constructor for DateTime

### DIFF
--- a/RTClib.h
+++ b/RTClib.h
@@ -29,7 +29,7 @@ class TimeSpan;
 // Simple general-purpose date/time class (no TZ / DST / leap second handling!)
 class DateTime {
 public:
-    DateTime (uint32_t t = 0);
+    DateTime (uint32_t t = SECONDS_FROM_1970_TO_2000);
     DateTime (uint16_t year, uint8_t month, uint8_t day,
                 uint8_t hour = 0, uint8_t min = 0, uint8_t sec = 0);
     DateTime (const DateTime& copy);


### PR DESCRIPTION
The default `DateTime` constructor is:

```c++
DateTime (uint32_t t =0);
```

which is presumably meant to represent the Unix epoch, i.e. 1970-01-01. However, due to an arithmetic rollover, it ends up being (2<sup>32</sup>&nbsp;s −&nbsp;1&nbsp;day) later¹, i.e. 2106-02-06 06:28:16.

This pull request changes the default constructor to

```c++
DateTime (uint32_t t = SECONDS_FROM_1970_TO_2000);
```

which represents 2000-01-01 00:00:00, i.e. the earliest time representable in the format used by the class. It fixes issue #91.

An alternative that was considered is:

```c++
DateTime(const char* date = __DATE__, const char* time = __TIME__);
```

It was rejected because:

1. This value does not make immediately clear to the user that the object has never been initialized.
2. If RTClib.h is included in different source files that are not compiled at the exact same time, then the default `DateTime` will not be consistent throughout the program.
3. If the compiled binary is moved across time zones, the default may end up being in the future.

¹ Note: The 1&nbsp;day offset is due to an error in the leap-year logic, which considers 2100 to be a leap year. This may be too far in the future to care about.