### PR TITLE
Add calibrate method to RTC_PCF8523

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -425,6 +425,16 @@ void RTC_PCF8523::writeSqwPinMode(Pcf8523SqwPinMode mode) {
   Wire.endTransmission();
 }
 
+void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
+  uint8_t reg = (uint8_t) offset & 0x7F;
+  reg |= mode;
+
+  Wire.beginTransmission(PCF8523_ADDRESS);
+  Wire._I2C_WRITE(PCF8523_OFFSET);
+  Wire._I2C_WRITE(reg);
+  Wire.endTransmission();
+}
+
 
 
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -11,6 +11,7 @@ class TimeSpan;
 #define PCF8523_ADDRESS       0x68
 #define PCF8523_CLKOUTCONTROL 0x0F
 #define PCF8523_CONTROL_3     0x02
+#define PCF8523_OFFSET        0x0E
 
 #define DS1307_ADDRESS  0x68
 #define DS1307_CONTROL  0x07
@@ -109,6 +110,8 @@ public:
 // RTC based on the PCF8523 chip connected via I2C and the Wire library
 enum Pcf8523SqwPinMode { PCF8523_OFF = 7, PCF8523_SquareWave1HZ = 6, PCF8523_SquareWave32HZ = 5, PCF8523_SquareWave1kHz = 4, PCF8523_SquareWave4kHz = 3, PCF8523_SquareWave8kHz = 2, PCF8523_SquareWave16kHz = 1, PCF8523_SquareWave32kHz = 0 };
 
+enum Pcf8523OffsetMode { PCF8523_TwoHours = 0x00, PCF8523_OneMinute = 0x80 };
+
 class RTC_PCF8523 {
 public:
     boolean begin(void);
@@ -118,6 +121,7 @@ public:
 
     Pcf8523SqwPinMode readSqwPinMode();
     void writeSqwPinMode(Pcf8523SqwPinMode mode);
+    void calibrate(Pcf8523OffsetMode mode, int8_t offset);
 };
 
 // RTC using the internal millis() clock, has to be initialized before use


### PR DESCRIPTION
- Scope: Adds a function to allow calibration of the PCF8523
- Limitations: Applies only to the PCF8523
- Example: http://www.takaitra.com/posts/686