### PR TITLE
Fix signed/unsigned compare warning bug

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1,8 +1,14 @@
 // Code by JeeLabs http://news.jeelabs.org/code/
 // Released to the public domain! Enjoy!
 
-#include <Wire.h>
 #include "RTClib.h"
+
+#ifdef USE_SBWIRE //Uncomment this definition in RTClib.h to avoid Wire library lockups
+#include <SBWire.h>
+#else
+#include <Wire.h>
+#endif // USE_SBWIRE
+
 #ifdef __AVR__
  #include <avr/pgmspace.h>
 #elif defined(ESP8266)

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -433,7 +433,11 @@ void RTC_PCF8523::writeSqwPinMode(Pcf8523SqwPinMode mode) {
 
 boolean RTC_DS3231::begin(void) {
   Wire.begin();
-  return true;
+
+  //02/16/19 gfp added to make begin() a bit more useful
+  Wire.beginTransmission(DS3231_ADDRESS);
+  int iLastError = Wire.endTransmission();
+  return (iLastError == 0x00);
 }
 
 bool RTC_DS3231::lostPower(void) {

--- a/RTClib.h
+++ b/RTClib.h
@@ -7,6 +7,8 @@
 #include <Arduino.h>
 class TimeSpan;
 
+#define USE_SBWIRE //uncomment this to use SBWire, which fixes Wire library lockup problems
+
 
 #define PCF8523_ADDRESS       0x68
 #define PCF8523_CLKOUTCONTROL 0x0F


### PR DESCRIPTION
Fix for Issue 99 - warning about signed/unsigned comparison mismatch

This pull request is for the fix to Issue #99 Warning when compiling.  The warning is caused by 
comparing an unsigned int 'day' to a signed int ('365' which is regarded as an 'int' by default).
The fix is to replace '365' by '365U' in two places, making 365 an unsigned int.
