### PR TITLE
Implement RTC_Micros with tunable drift

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -360,6 +360,32 @@ DateTime RTC_Millis::now() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// RTC_Micros implementation
+
+// Number of microseconds reported by micros() per "true" (calibrated)
+// second.
+uint32_t RTC_Micros::microsPerSecond = 1000000;
+
+// The timing logic is identical to RTC_Millis.
+uint32_t RTC_Micros::lastMicros;
+uint32_t RTC_Micros::lastUnix;
+
+void RTC_Micros::adjust(const DateTime& dt) {
+  lastMicros = micros();
+  lastUnix = dt.unixtime();
+}
+
+// A positive adjustment makes the clock faster.
+void RTC_Micros::adjustDrift(int ppm) {
+  microsPerSecond = 1000000 - ppm;
+}
+
+DateTime RTC_Micros::now() {
+  uint32_t elapsedSeconds = (micros() - lastMicros) / microsPerSecond;
+  lastMicros += elapsedSeconds * microsPerSecond;
+  lastUnix += elapsedSeconds;
+  return lastUnix;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // RTC_PCF8563 implementation

--- a/RTClib.h
+++ b/RTClib.h
@@ -133,4 +133,22 @@ protected:
     static uint32_t lastMillis;
 };
 
+// RTC using the internal micros() clock, has to be initialized before
+// use. Unlike RTC_Millis, this can be tuned in order to compensate for
+// the natural drift of the system clock. Note that now() has to be
+// called more frequently than the micros() rollover period, which is
+// approximately 71.6 minutes.
+class RTC_Micros {
+public:
+    static void begin(const DateTime& dt) { adjust(dt); }
+    static void adjust(const DateTime& dt);
+    static void adjustDrift(int ppm);
+    static DateTime now();
+
+protected:
+    static uint32_t microsPerSecond;
+    static uint32_t lastUnix;
+    static uint32_t lastMicros;
+};
+
 #endif // _RTCLIB_H_

--- a/RTClib.h
+++ b/RTClib.h
@@ -121,7 +121,7 @@ public:
 };
 
 // RTC using the internal millis() clock, has to be initialized before use
-// NOTE: this clock won't be correct once the millis() timer rolls over (>49d?)
+// NOTE: this is immune to millis() rollover events
 class RTC_Millis {
 public:
     static void begin(const DateTime& dt) { adjust(dt); }
@@ -129,7 +129,8 @@ public:
     static DateTime now();
 
 protected:
-    static long offset;
+    static uint32_t lastUnix;
+    static uint32_t lastMillis;
 };
 
 #endif // _RTCLIB_H_

--- a/keywords.txt
+++ b/keywords.txt
@@ -10,6 +10,7 @@ DateTime	KEYWORD1
 TimeSpan	KEYWORD1
 RTC_DS1307	KEYWORD1
 RTC_Millis	KEYWORD1
+RTC_Micros	KEYWORD1
 Ds1307SqwPinMode	KEYWORD1
 
 #######################################
@@ -27,6 +28,7 @@ secondstime	KEYWORD2
 unixtime	KEYWORD2
 begin	KEYWORD2
 adjust	KEYWORD2
+adjustDrift	KEYWORD2
 isrunning	KEYWORD2
 now	KEYWORD2
 readSqwPinMode	KEYWORD2


### PR DESCRIPTION
Most Arduinos are clocked off a ceramic resonator which is notably inaccurate for timekeeping. Drift rates can be of the order of 1,000&nbsp;ppm, i.e. more than a minute per day. This severely limits the usefulness of `RTC_Millis`. However, if the user can measure the drift rate of his Arduino's clock, the software could in principle use this measurement to compensate and “calibrate out” the drift.

This pull request implements a variation on the `RTC_Millis` idea with adjustable drift, but based on `micros()` instead of `millis()`. It provides the method

```c++
void RTC_Micros::adjustDrift(int ppm);
```

that can be used to tune the drift with 1&nbsp;ppm resolution. A finer resolution would not be useful, as the frequency of the ceramic resonator is not very stable and [can change by more than 1&nbsp;ppm in just an hour][arduino-frequency].

The only drawback of this `RTC_Micros` class is that the `now()` method has to be called at least once every 71.58&nbsp;minutes in order to prevent rollover issues.

Note that this pull request depends on #92: _Make RTC\_Millis immune to millis() rollover events_. The reason is that it is essential for `RTC_Micros` to be immune to rollover events, and it would make little sense to have this class alongside an `RTC_Millis` that suffers from a rollover bug.

[arduino-frequency]: http://jorisvr.nl/article/arduino-frequency