### PR TITLE
Added comparison operators to DateTime class

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -207,6 +207,14 @@ TimeSpan DateTime::operator-(const DateTime& right) {
   return TimeSpan(unixtime()-right.unixtime());
 }
 
+bool DateTime::operator<(const DateTime& right) const {
+  return unixtime() < right.unixtime();
+}
+
+bool DateTime::operator==(const DateTime &right) const {
+  return unixtime() == right.unixtime();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // TimeSpan implementation
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -51,6 +51,12 @@ public:
     DateTime operator+(const TimeSpan& span);
     DateTime operator-(const TimeSpan& span);
     TimeSpan operator-(const DateTime& right);
+    bool operator<(const DateTime& right) const;
+    bool operator>(const DateTime& right) const  { return right < *this; }
+    bool operator<=(const DateTime& right) const { return !(*this > right); }
+    bool operator>=(const DateTime& right) const { return !(*this < right); }
+    bool operator==(const DateTime& right) const;
+    bool operator!=(const DateTime& right) const { return !(*this == right); }
 
 protected:
     uint8_t yOff, m, d, hh, mm, ss;


### PR DESCRIPTION
**Scope**: I added comparison operators (`>`, `<`, `>=`, `<=`, `==` and `!=`) to DateTime class. I've implemented operators `<` and `==` based on `unixtime()` method, and derived the other ones by using boolean operations.

**Known limitations**: same as the already existing `unixtime()` method

**Tests**: I ran the code below on an Arduino Nano connected to a DS1307 RTC module:

```c++
#include "Arduino.h"
#include "Wire.h"
#include "RTClib.h"

RTC_DS1307 g_rtc;

String dateTimeToString(DateTime &dt)
{
  char buffer[50];

  sprintf(buffer, "%d/%d/%d %02d:%02d:%02d",
    dt.day(), dt.month(), dt.year(),
    dt.hour(), dt.minute(), dt.second());

  return String(buffer);
}

char boolString[2][6] = {"false", "true"};

void setup()
{
  Serial.begin(9600);
  Wire.begin();

  DateTime d1(2019, 05, 06, 19, 0, 0);
  DateTime d2(2019, 05, 06, 20, 0, 0);
  DateTime d3(2019, 05, 06, 20, 0, 0);

  DateTime now = g_rtc.now();


  Serial.print("d1:  ");
  Serial.println(dateTimeToString(d1));
  Serial.print("d2:  ");
  Serial.println(dateTimeToString(d2));
  Serial.print("d3:  ");
  Serial.println(dateTimeToString(d3));
  Serial.print("now: ");
  Serial.println(dateTimeToString(now));
  Serial.println("");

  Serial.print("d1 < d2 : ");
  Serial.println(boolString[d1 < d2]);

  Serial.print("d1 > d2 : ");
  Serial.println(boolString[d1 > d2]);

  Serial.print("d2 == d3 : ");
  Serial.println(boolString[d2 == d3]);

  Serial.print("d2 != d3 : ");
  Serial.println(boolString[d2 != d3]);

  Serial.print("d1 <= d2 : ");
  Serial.println(boolString[d1 <= d2]);

  Serial.print("d2 >= d3 : ");
  Serial.println(boolString[d2 >= d3]);

  Serial.print("now < d1 : ");
  Serial.println(boolString[now < d1]);

  Serial.print("now < d2 : ");
  Serial.println(boolString[now < d2]);
}

void loop()
{ }
```

The Serial monitor output is shown below:

```plain
d1:  6/5/2019 19:00:00
d2:  6/5/2019 20:00:00
d3:  6/5/2019 20:00:00
now: 6/5/2019 19:42:38

d1 < d2 : true
d1 > d2 : false
d2 == d3 : true
d2 != d3 : false
d1 <= d2 : true
d2 >= d3 : true
now < d1 : false
now < d2 : true
```

This closes  issue #67 