### PR TITLE
Doxygen docs; DS1307 enum prefixes; Example cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+html
+Doxyfile*
+doxygen_sqlite3.db

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1,5 +1,27 @@
-// Code by JeeLabs http://news.jeelabs.org/code/
-// Released to the public domain! Enjoy!
+/**************************************************************************/
+/*!
+  @file     RTClib.cpp
+
+  @mainpage Adafruit RTClib
+
+  @section intro Introduction
+
+  This is a fork of JeeLab's fantastic real time clock library for Arduino.
+
+  For details on using this library with an RTC module like the DS1307, PCF8523, or DS3231,
+  see the guide at: https://learn.adafruit.com/ds1307-real-time-clock-breakout-board-kit/overview
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  @section license License
+
+  Original library by JeeLabs http://news.jeelabs.org/code/, released to the public domain.
+
+  This version: MIT (see LICENSE)
+*/
+/**************************************************************************/
 
 #ifdef __AVR_ATtiny85__
  #include <TinyWireM.h>
@@ -26,15 +48,23 @@
 #if (ARDUINO >= 100)
  #include <Arduino.h> // capital A so it is error prone on case-sensitive filesystems
  // Macro to deal with the difference in I2C write functions from old and new Arduino versions.
- #define _I2C_WRITE write
- #define _I2C_READ  read
+ #define _I2C_WRITE write   ///< Modern I2C write
+ #define _I2C_READ  read    ///< Modern I2C read
 #else
  #include <WProgram.h>
- #define _I2C_WRITE send
- #define _I2C_READ  receive
+ #define _I2C_WRITE send    ///< Legacy I2C write
+ #define _I2C_READ  receive ///< legacy I2C read
 #endif
 
 
+/**************************************************************************/
+/*!
+    @brief  Read a byte from an I2C register
+    @param addr I2C address
+    @param reg Register address
+    @return Register value
+*/
+/**************************************************************************/
 static uint8_t read_i2c_register(uint8_t addr, uint8_t reg) {
   Wire.beginTransmission(addr);
   Wire._I2C_WRITE((byte)reg);
@@ -44,6 +74,14 @@ static uint8_t read_i2c_register(uint8_t addr, uint8_t reg) {
   return Wire._I2C_READ();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Write a byte to an I2C register
+    @param addr I2C address
+    @param reg Register address
+    @param val Value to write
+*/
+/**************************************************************************/
 static void write_i2c_register(uint8_t addr, uint8_t reg, uint8_t val) {
   Wire.beginTransmission(addr);
   Wire._I2C_WRITE((byte)reg);
@@ -52,12 +90,22 @@ static void write_i2c_register(uint8_t addr, uint8_t reg, uint8_t val) {
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
+/**************************************************************************/
 // utility code, some of this could be exposed in the DateTime API if needed
+/**************************************************************************/
 
+/** Number of days in each month */
 const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
 
-// number of days since 2000/01/01, valid for 2001..2099
+/**************************************************************************/
+/*!
+    @brief  Given a date, return number of days since 2000/01/01, valid for 2001..2099
+    @param y Year
+    @param m Month
+    @param d Day
+    @return Number of days
+*/
+/**************************************************************************/
 static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {
     if (y >= 2000)
         y -= 2000;
@@ -69,41 +117,66 @@ static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {
     return days + 365 * y + (y + 3) / 4 - 1;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Given a number of days, hours, minutes, and seconds, return the total seconds
+    @param days Days
+    @param h Hours
+    @param m Minutes
+    @param s Seconds
+    @return Number of seconds total
+*/
+/**************************************************************************/
 static long time2long(uint16_t days, uint8_t h, uint8_t m, uint8_t s) {
     return ((days * 24L + h) * 60 + m) * 60 + s;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// DateTime implementation - ignores time zones and DST changes
-// NOTE: also ignores leap seconds, see http://en.wikipedia.org/wiki/Leap_second
 
+
+/**************************************************************************/
+/*!
+    @brief  DateTime constructor from unixtime
+    @param t Initial time in seconds since Jan 1, 1970 (Unix time)
+*/
+/**************************************************************************/
 DateTime::DateTime (uint32_t t) {
   t -= SECONDS_FROM_1970_TO_2000;    // bring to 2000 timestamp from 1970
 
-    ss = t % 60;
-    t /= 60;
-    mm = t % 60;
-    t /= 60;
-    hh = t % 24;
-    uint16_t days = t / 24;
-    uint8_t leap;
-    for (yOff = 0; ; ++yOff) {
-        leap = yOff % 4 == 0;
-        if (days < 365 + leap)
-            break;
-        days -= 365 + leap;
-    }
-    for (m = 1; ; ++m) {
-        uint8_t daysPerMonth = pgm_read_byte(daysInMonth + m - 1);
-        if (leap && m == 2)
-            ++daysPerMonth;
-        if (days < daysPerMonth)
-            break;
-        days -= daysPerMonth;
-    }
-    d = days + 1;
+  ss = t % 60;
+  t /= 60;
+  mm = t % 60;
+  t /= 60;
+  hh = t % 24;
+  uint16_t days = t / 24;
+  uint8_t leap;
+  for (yOff = 0; ; ++yOff) {
+    leap = yOff % 4 == 0;
+    if (days < 365 + leap)
+      break;
+    days -= 365 + leap;
+  }
+  for (m = 1; ; ++m) {
+    uint8_t daysPerMonth = pgm_read_byte(daysInMonth + m - 1);
+    if (leap && m == 2)
+      ++daysPerMonth;
+    if (days < daysPerMonth)
+      break;
+    days -= daysPerMonth;
+  }
+  d = days + 1;
 }
 
+/**************************************************************************/
+/*!
+    @brief  DateTime constructor from Y-M-D H:M:S
+    @param year Year, 2 or 4 digits (year 2000 or higher)
+    @param month Month 1-12
+    @param day Day 1-31
+    @param hour 0-23
+    @param min 0-59
+    @param sec 0-59
+*/
+/**************************************************************************/
 DateTime::DateTime (uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec) {
     if (year >= 2000)
         year -= 2000;
@@ -115,6 +188,12 @@ DateTime::DateTime (uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uin
     ss = sec;
 }
 
+/**************************************************************************/
+/*!
+    @brief  DateTime copy constructor using a member initializer list
+    @param copy DateTime object to copy
+*/
+/**************************************************************************/
 DateTime::DateTime (const DateTime& copy):
   yOff(copy.yOff),
   m(copy.m),
@@ -124,6 +203,12 @@ DateTime::DateTime (const DateTime& copy):
   ss(copy.ss)
 {}
 
+/**************************************************************************/
+/*!
+    @brief  Convert a string containing two digits to uint8_t, e.g. "09" returns 9
+    @param p Pointer to a string containing two digits
+*/
+/**************************************************************************/
 static uint8_t conv2d(const char* p) {
     uint8_t v = 0;
     if ('0' <= *p && *p <= '9')
@@ -131,9 +216,15 @@ static uint8_t conv2d(const char* p) {
     return 10 * v + *++p - '0';
 }
 
-// A convenient constructor for using "the compiler's time":
-//   DateTime now (__DATE__, __TIME__);
-// NOTE: using F() would further reduce the RAM footprint, see below.
+/**************************************************************************/
+/*!
+    @brief  A convenient constructor for using "the compiler's time":
+            DateTime now (__DATE__, __TIME__);
+            NOTE: using F() would further reduce the RAM footprint, see below.
+    @param date Date string, e.g. "Dec 26 2009"
+    @param time Time string, e.g. "12:34:56"
+*/
+/**************************************************************************/
 DateTime::DateTime (const char* date, const char* time) {
     // sample input: date = "Dec 26 2009", time = "12:34:56"
     yOff = conv2d(date + 9);
@@ -154,9 +245,15 @@ DateTime::DateTime (const char* date, const char* time) {
     ss = conv2d(time + 6);
 }
 
-// A convenient constructor for using "the compiler's time":
-// This version will save RAM by using PROGMEM to store it by using the F macro.
-//   DateTime now (F(__DATE__), F(__TIME__));
+/**************************************************************************/
+/*!
+    @brief  A convenient constructor for using "the compiler's time":
+            This version will save RAM by using PROGMEM to store it by using the F macro.
+            DateTime now (F(__DATE__), F(__TIME__));
+    @param date Date string, e.g. "Dec 26 2009"
+    @param time Time string, e.g. "12:34:56"
+*/
+/**************************************************************************/
 DateTime::DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time) {
     // sample input: date = "Dec 26 2009", time = "12:34:56"
     char buff[11];
@@ -180,11 +277,23 @@ DateTime::DateTime (const __FlashStringHelper* date, const __FlashStringHelper* 
     ss = conv2d(buff + 6);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Return the day of the week for this object, from 0-6.
+    @return Day of week 0-6 starting with Sunday, e.g. Sunday = 0, Saturday = 6
+*/
+/**************************************************************************/
 uint8_t DateTime::dayOfTheWeek() const {
     uint16_t day = date2days(yOff, m, d);
     return (day + 6) % 7; // Jan 1, 2000 is a Saturday, i.e. returns 6
 }
 
+/**************************************************************************/
+/*!
+    @brief  Return unix time, seconds since Jan 1, 1970.
+    @return Number of seconds since Jan 1, 1970
+*/
+/**************************************************************************/
 uint32_t DateTime::unixtime(void) const {
   uint32_t t;
   uint16_t days = date2days(yOff, m, d);
@@ -194,6 +303,12 @@ uint32_t DateTime::unixtime(void) const {
   return t;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Convert the DateTime to seconds
+    @return The object as seconds since 2000-01-01
+*/
+/**************************************************************************/
 long DateTime::secondstime(void) const {
   long t;
   uint16_t days = date2days(yOff, m, d);
@@ -201,27 +316,68 @@ long DateTime::secondstime(void) const {
   return t;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Add a TimeSpan to the DateTime object
+    @param span TimeSpan object
+    @return new DateTime object with span added to it
+*/
+/**************************************************************************/
 DateTime DateTime::operator+(const TimeSpan& span) {
   return DateTime(unixtime()+span.totalseconds());
 }
 
+/**************************************************************************/
+/*!
+    @brief  Subtract a TimeSpan from the DateTime object
+    @param span TimeSpan object
+    @return new DateTime object with span subtracted from it
+*/
+/**************************************************************************/
 DateTime DateTime::operator-(const TimeSpan& span) {
   return DateTime(unixtime()-span.totalseconds());
 }
 
+/**************************************************************************/
+/*!
+    @brief  Subtract one DateTime from another
+    @param right The DateTime object to subtract from self (the left object)
+    @return TimeSpan of the difference between DateTimes
+*/
+/**************************************************************************/
 TimeSpan DateTime::operator-(const DateTime& right) {
   return TimeSpan(unixtime()-right.unixtime());
 }
 
+/**************************************************************************/
+/*!
+    @brief  Is one DateTime object less than (older) than the other?
+    @param right Comparison DateTime object
+    @return True if the left object is older than the right object
+*/
+/**************************************************************************/
 bool DateTime::operator<(const DateTime& right) const {
   return unixtime() < right.unixtime();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Is one DateTime object equal to the other?
+    @param right Comparison DateTime object
+    @return True if both DateTime objects are the same
+*/
+/**************************************************************************/
 bool DateTime::operator==(const DateTime& right) const {
   return unixtime() == right.unixtime();
 }
 
-//ISO 8601 Timestamp
+/**************************************************************************/
+/*!
+    @brief  ISO 8601 Timestamp
+    @param opt Format of the timestamp
+    @return Timestamp string, e.g. "2000-01-01T12:34:56"
+*/
+/**************************************************************************/
 String DateTime::timestamp(timestampOpt opt){
   char buffer[20];
 
@@ -242,40 +398,103 @@ String DateTime::timestamp(timestampOpt opt){
   return String(buffer);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// TimeSpan implementation
 
+
+/**************************************************************************/
+/*!
+    @brief  Create a new TimeSpan object in seconds
+    @param seconds Number of seconds
+*/
+/**************************************************************************/
 TimeSpan::TimeSpan (int32_t seconds):
   _seconds(seconds)
 {}
 
+/**************************************************************************/
+/*!
+    @brief  Create a new TimeSpan object using a number of days/hours/minutes/seconds
+            e.g. Make a TimeSpan of 3 hours and 45 minutes: new TimeSpan(0, 3, 45, 0);
+    @param days Number of days
+    @param hours Number of hours
+    @param minutes Number of minutes
+    @param seconds Number of seconds
+*/
+/**************************************************************************/
 TimeSpan::TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds):
   _seconds((int32_t)days*86400L + (int32_t)hours*3600 + (int32_t)minutes*60 + seconds)
 {}
 
+/**************************************************************************/
+/*!
+    @brief  Copy constructor, make a new TimeSpan using an existing one
+    @param copy The TimeSpan to copy
+*/
+/**************************************************************************/
 TimeSpan::TimeSpan (const TimeSpan& copy):
   _seconds(copy._seconds)
 {}
 
+/**************************************************************************/
+/*!
+    @brief  Add two TimeSpans
+    @param right TimeSpan to add
+    @return New TimeSpan object, sum of left and right
+*/
+/**************************************************************************/
 TimeSpan TimeSpan::operator+(const TimeSpan& right) {
   return TimeSpan(_seconds+right._seconds);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Subtract a TimeSpan
+    @param right TimeSpan to subtract
+    @return New TimeSpan object, right subtracted from left
+*/
+/**************************************************************************/
 TimeSpan TimeSpan::operator-(const TimeSpan& right) {
   return TimeSpan(_seconds-right._seconds);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// RTC_DS1307 implementation
 
+
+/**************************************************************************/
+/*!
+    @brief  Convert a binary coded decimal value to binary. RTC stores time/date values as BCD.
+    @param val BCD value
+    @return Binary value
+*/
+/**************************************************************************/
 static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4); }
+
+/**************************************************************************/
+/*!
+    @brief  Convert a binary value to BCD format for the RTC registers
+    @param val Binary value
+    @return BCD value
+*/
+/**************************************************************************/
 static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10); }
 
+
+
+/**************************************************************************/
+/*!
+    @brief  Startup for the DS1307
+    @return Always true
+*/
+/**************************************************************************/
 boolean RTC_DS1307::begin(void) {
   Wire.begin();
   return true;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Is the DS1307 running? Check the Clock Halt bit in register 0
+    @return 1 if the RTC is running, 0 if not
+*/
+/**************************************************************************/
 uint8_t RTC_DS1307::isrunning(void) {
   Wire.beginTransmission(DS1307_ADDRESS);
   Wire._I2C_WRITE((byte)0);
@@ -286,6 +505,12 @@ uint8_t RTC_DS1307::isrunning(void) {
   return !(ss>>7);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the date and time in the DS1307
+    @param dt DateTime object containing the desired date/time
+*/
+/**************************************************************************/
 void RTC_DS1307::adjust(const DateTime& dt) {
   Wire.beginTransmission(DS1307_ADDRESS);
   Wire._I2C_WRITE((byte)0); // start at location 0
@@ -299,6 +524,12 @@ void RTC_DS1307::adjust(const DateTime& dt) {
   Wire.endTransmission();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current date and time from the DS1307
+    @return DateTime object containing the current date and time
+*/
+/**************************************************************************/
 DateTime RTC_DS1307::now() {
   Wire.beginTransmission(DS1307_ADDRESS);
   Wire._I2C_WRITE((byte)0);
@@ -316,6 +547,12 @@ DateTime RTC_DS1307::now() {
   return DateTime (y, m, d, hh, mm, ss);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Read the current mode of the SQW pin
+    @return Mode as Ds1307SqwPinMode enum
+*/
+/**************************************************************************/
 Ds1307SqwPinMode RTC_DS1307::readSqwPinMode() {
   int mode;
 
@@ -330,6 +567,12 @@ Ds1307SqwPinMode RTC_DS1307::readSqwPinMode() {
   return static_cast<Ds1307SqwPinMode>(mode);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Change the SQW pin mode
+    @param mode The mode to use
+*/
+/**************************************************************************/
 void RTC_DS1307::writeSqwPinMode(Ds1307SqwPinMode mode) {
   Wire.beginTransmission(DS1307_ADDRESS);
   Wire._I2C_WRITE(DS1307_CONTROL);
@@ -337,6 +580,14 @@ void RTC_DS1307::writeSqwPinMode(Ds1307SqwPinMode mode) {
   Wire.endTransmission();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Read data from the DS1307's NVRAM
+    @param buf Pointer to a buffer to store the data - make sure it's large enough to hold size bytes
+    @param size Number of bytes to read
+    @param address Starting NVRAM address, from 0 to 55
+*/
+/**************************************************************************/
 void RTC_DS1307::readnvram(uint8_t* buf, uint8_t size, uint8_t address) {
   int addrByte = DS1307_NVRAM + address;
   Wire.beginTransmission(DS1307_ADDRESS);
@@ -349,6 +600,14 @@ void RTC_DS1307::readnvram(uint8_t* buf, uint8_t size, uint8_t address) {
   }
 }
 
+/**************************************************************************/
+/*!
+    @brief  Write data to the DS1307 NVRAM
+    @param address Starting NVRAM address, from 0 to 55
+    @param buf Pointer to buffer containing the data to write
+    @param size Number of bytes in buf to write to NVRAM
+*/
+/**************************************************************************/
 void RTC_DS1307::writenvram(uint8_t address, uint8_t* buf, uint8_t size) {
   int addrByte = DS1307_NVRAM + address;
   Wire.beginTransmission(DS1307_ADDRESS);
@@ -359,34 +618,59 @@ void RTC_DS1307::writenvram(uint8_t address, uint8_t* buf, uint8_t size) {
   Wire.endTransmission();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Shortcut to read one byte from NVRAM
+    @param address NVRAM address, 0 to 55
+    @return The byte read from NVRAM
+*/
+/**************************************************************************/
 uint8_t RTC_DS1307::readnvram(uint8_t address) {
   uint8_t data;
   readnvram(&data, 1, address);
   return data;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Shortcut to write one byte to NVRAM
+    @param address NVRAM address, 0 to 55
+    @param data One byte to write
+*/
+/**************************************************************************/
 void RTC_DS1307::writenvram(uint8_t address, uint8_t data) {
   writenvram(address, &data, 1);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// RTC_Millis implementation
 
-// Alignment between the milis() timescale and the Unix timescale. These
-// two variables are updated on each call to now(), which prevents
-// rollover issues. Note that lastMillis is **not** the millis() value
-// of the last call to now(): it's the millis() value corresponding to
-// the last **full second** of Unix time.
+
+/** Alignment between the milis() timescale and the Unix timescale. These
+  two variables are updated on each call to now(), which prevents
+  rollover issues. Note that lastMillis is **not** the millis() value
+  of the last call to now(): it's the millis() value corresponding to
+  the last **full second** of Unix time. */
 uint32_t RTC_Millis::lastMillis;
 uint32_t RTC_Millis::lastUnix;
 
+/**************************************************************************/
+/*!
+    @brief  Set the current date/time of the RTC_Millis clock.
+    @param dt DateTime object with the desired date and time
+*/
+/**************************************************************************/
 void RTC_Millis::adjust(const DateTime& dt) {
   lastMillis = millis();
   lastUnix = dt.unixtime();
 }
 
-// Note that computing (millis() - lastMillis) is rollover-safe as long
-// as this method is called at least once every 49.7 days.
+/**************************************************************************/
+/*!
+    @brief  Return a DateTime object containing the current date/time.
+            Note that computing (millis() - lastMillis) is rollover-safe as long
+            as this method is called at least once every 49.7 days.
+    @return DateTime object containing current time
+*/
+/**************************************************************************/
 DateTime RTC_Millis::now() {
   uint32_t elapsedSeconds = (millis() - lastMillis) / 1000;
   lastMillis += elapsedSeconds * 1000;
@@ -394,27 +678,43 @@ DateTime RTC_Millis::now() {
   return lastUnix;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// RTC_Micros implementation
 
-// Number of microseconds reported by micros() per "true" (calibrated)
-// second.
+
+/** Number of microseconds reported by micros() per "true" (calibrated) second. */
 uint32_t RTC_Micros::microsPerSecond = 1000000;
 
-// The timing logic is identical to RTC_Millis.
+/** The timing logic is identical to RTC_Millis. */
 uint32_t RTC_Micros::lastMicros;
 uint32_t RTC_Micros::lastUnix;
 
+/**************************************************************************/
+/*!
+    @brief  Set the current date/time of the RTC_Micros clock.
+    @param dt DateTime object with the desired date and time
+*/
+/**************************************************************************/
 void RTC_Micros::adjust(const DateTime& dt) {
   lastMicros = micros();
   lastUnix = dt.unixtime();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Adjust the RTC_Micros clock to compensate for system clock drift
+    @param ppm Adjustment to make
+*/
+/**************************************************************************/
 // A positive adjustment makes the clock faster.
 void RTC_Micros::adjustDrift(int ppm) {
   microsPerSecond = 1000000 - ppm;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current date/time from the RTC_Micros clock.
+    @return DateTime object containing the current date/time
+*/
+/**************************************************************************/
 DateTime RTC_Micros::now() {
   uint32_t elapsedSeconds = (micros() - lastMicros) / microsPerSecond;
   lastMicros += elapsedSeconds * microsPerSecond;
@@ -422,14 +722,27 @@ DateTime RTC_Micros::now() {
   return lastUnix;
 }
 
+
+
+/**************************************************************************/
+/*!
+    @brief  Start using the PCF8523
+    @return True
+*/
+/**************************************************************************/
 ////////////////////////////////////////////////////////////////////////////////
 // RTC_PCF8563 implementation
-
 boolean RTC_PCF8523::begin(void) {
   Wire.begin();
   return true;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Check control register 3 to see if we've run adjust() yet (setting the date/time and battery switchover mode)
+    @return True if the PCF8523 has been set up, false if not
+*/
+/**************************************************************************/
 boolean RTC_PCF8523::initialized(void) {
   Wire.beginTransmission(PCF8523_ADDRESS);
   Wire._I2C_WRITE((byte)PCF8523_CONTROL_3);
@@ -440,6 +753,12 @@ boolean RTC_PCF8523::initialized(void) {
   return ((ss & 0xE0) != 0xE0);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the date and time, set battery switchover mode
+    @param dt DateTime to set
+*/
+/**************************************************************************/
 void RTC_PCF8523::adjust(const DateTime& dt) {
   Wire.beginTransmission(PCF8523_ADDRESS);
   Wire._I2C_WRITE((byte)3); // start at location 3
@@ -459,6 +778,12 @@ void RTC_PCF8523::adjust(const DateTime& dt) {
   Wire.endTransmission();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current date/time
+    @return DateTime object containing the current date/time
+*/
+/**************************************************************************/
 DateTime RTC_PCF8523::now() {
   Wire.beginTransmission(PCF8523_ADDRESS);
   Wire._I2C_WRITE((byte)3);
@@ -476,6 +801,12 @@ DateTime RTC_PCF8523::now() {
   return DateTime (y, m, d, hh, mm, ss);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Read the mode of the SQW pin on the PCF8523
+    @return SQW pin mode as a Pcf8523SqwPinMode enum
+*/
+/**************************************************************************/
 Pcf8523SqwPinMode RTC_PCF8523::readSqwPinMode() {
   int mode;
 
@@ -491,6 +822,12 @@ Pcf8523SqwPinMode RTC_PCF8523::readSqwPinMode() {
   return static_cast<Pcf8523SqwPinMode>(mode);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the SQW pin mode on the PCF8523
+    @param mode The mode to set, see the Pcf8523SqwPinMode enum for options
+*/
+/**************************************************************************/
 void RTC_PCF8523::writeSqwPinMode(Pcf8523SqwPinMode mode) {
   Wire.beginTransmission(PCF8523_ADDRESS);
   Wire._I2C_WRITE(PCF8523_CLKOUTCONTROL);
@@ -498,6 +835,16 @@ void RTC_PCF8523::writeSqwPinMode(Pcf8523SqwPinMode mode) {
   Wire.endTransmission();
 }
 
+/**************************************************************************/
+/*!
+    @brief  Use an offset to calibrate the PCF8523. This can be used for:
+            - Aging adjustment
+            - Temperature compensation
+            - Accuracy tuning
+    @param mode The offset mode to use, once every two hours or once every minute. See the Pcf8523OffsetMode enum.
+    @param offset Offset value from -64 to +63. See the datasheet for exact ppm values.
+*/
+/**************************************************************************/
 void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
   uint8_t reg = (uint8_t) offset & 0x7F;
   reg |= mode;
@@ -510,19 +857,33 @@ void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
 
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-// RTC_DS3231 implementation
-
+/**************************************************************************/
+/*!
+    @brief  Start I2C for the DS3231
+    @return True
+*/
+/**************************************************************************/
 boolean RTC_DS3231::begin(void) {
   Wire.begin();
   return true;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Check the status register Oscillator Stop Flag to see if the DS3231 stopped due to power loss
+    @return True if the bit is set (oscillator stopped) or false if it is running
+*/
+/**************************************************************************/
 bool RTC_DS3231::lostPower(void) {
   return (read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG) >> 7);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the date and flip the Oscillator Stop Flag
+    @param dt DateTime object containing the date/time to set
+*/
+/**************************************************************************/
 void RTC_DS3231::adjust(const DateTime& dt) {
   Wire.beginTransmission(DS3231_ADDRESS);
   Wire._I2C_WRITE((byte)0); // start at location 0
@@ -540,6 +901,12 @@ void RTC_DS3231::adjust(const DateTime& dt) {
   write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, statreg);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current date/time
+    @return DateTime object with the current date/time
+*/
+/**************************************************************************/
 DateTime RTC_DS3231::now() {
   Wire.beginTransmission(DS3231_ADDRESS);
   Wire._I2C_WRITE((byte)0);
@@ -557,6 +924,12 @@ DateTime RTC_DS3231::now() {
   return DateTime (y, m, d, hh, mm, ss);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Read the SQW pin mode
+    @return Pin mode, see Ds3231SqwPinMode enum
+*/
+/**************************************************************************/
 Ds3231SqwPinMode RTC_DS3231::readSqwPinMode() {
   int mode;
 
@@ -571,6 +944,12 @@ Ds3231SqwPinMode RTC_DS3231::readSqwPinMode() {
   return static_cast<Ds3231SqwPinMode>(mode);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the SQW pin mode
+    @param mode Desired mode, see Ds3231SqwPinMode enum
+*/
+/**************************************************************************/
 void RTC_DS3231::writeSqwPinMode(Ds3231SqwPinMode mode) {
   uint8_t ctrl;
   ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
@@ -588,6 +967,12 @@ void RTC_DS3231::writeSqwPinMode(Ds3231SqwPinMode mode) {
   //Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL), HEX);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current temperature from the DS3231's temperature sensor
+    @return Current temperature (float)
+*/
+/**************************************************************************/
 float RTC_DS3231::getTemperature()
 {
   uint8_t msb, lsb;

--- a/RTClib.h
+++ b/RTClib.h
@@ -1,5 +1,21 @@
-// Code by JeeLabs http://news.jeelabs.org/code/
-// Released to the public domain! Enjoy!
+/**************************************************************************/
+/*!
+  @file     RTClib.h
+
+  Original library by JeeLabs http://news.jeelabs.org/code/, released to the public domain
+
+  License: MIT (see LICENSE)
+
+  This is a fork of JeeLab's fantastic real time clock library for Arduino.
+
+  For details on using this library with an RTC module like the DS1307, PCF8523, or DS3231,
+  see the guide at: https://learn.adafruit.com/ds1307-real-time-clock-breakout-board-kit/overview
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+*/
+/**************************************************************************/
 
 #ifndef _RTCLIB_H_
 #define _RTCLIB_H_
@@ -7,166 +23,322 @@
 #include <Arduino.h>
 class TimeSpan;
 
+/** Registers */
+#define PCF8523_ADDRESS       0x68  ///< I2C address for PCF8523
+#define PCF8523_CLKOUTCONTROL 0x0F  ///< Timer and CLKOUT control register
+#define PCF8523_CONTROL_3     0x02  ///< Control and status register 3
+#define PCF8523_OFFSET        0x0E  ///< Offset register
 
-#define PCF8523_ADDRESS       0x68
-#define PCF8523_CLKOUTCONTROL 0x0F
-#define PCF8523_CONTROL_3     0x02
-#define PCF8523_OFFSET        0x0E
+#define DS1307_ADDRESS        0x68  ///< I2C address for DS1307
+#define DS1307_CONTROL        0x07  ///< Control register
+#define DS1307_NVRAM          0x08  ///< Start of RAM registers - 56 bytes, 0x08 to 0x3f
 
-#define DS1307_ADDRESS  0x68
-#define DS1307_CONTROL  0x07
-#define DS1307_NVRAM    0x08
+#define DS3231_ADDRESS        0x68  ///< I2C address for DS3231
+#define DS3231_CONTROL        0x0E  ///< Control register
+#define DS3231_STATUSREG      0x0F  ///< Status register
+#define DS3231_TEMPERATUREREG	0x11  ///< Temperature register (high byte - low byte is at 0x12), 10-bit temperature value
 
-#define DS3231_ADDRESS  0x68
-#define DS3231_CONTROL  0x0E
-#define DS3231_STATUSREG 0x0F
-#define DS3231_TEMPERATUREREG	0x11
-
-#define SECONDS_PER_DAY 86400L
-
-#define SECONDS_FROM_1970_TO_2000 946684800
+/** Constants */
+#define SECONDS_PER_DAY       86400L  ///< 60 * 60 * 24
+#define SECONDS_FROM_1970_TO_2000 946684800  ///< Unixtime for 2000-01-01 00:00:00, useful for initialization
 
 
-
-// Simple general-purpose date/time class (no TZ / DST / leap second handling!)
+/**************************************************************************/
+/*!
+    @brief  Simple general-purpose date/time class (no TZ / DST / leap second handling!).
+            See http://en.wikipedia.org/wiki/Leap_second
+*/
+/**************************************************************************/
 class DateTime {
 public:
-    DateTime (uint32_t t = SECONDS_FROM_1970_TO_2000);
-    DateTime (uint16_t year, uint8_t month, uint8_t day,
-                uint8_t hour = 0, uint8_t min = 0, uint8_t sec = 0);
-    DateTime (const DateTime& copy);
-    DateTime (const char* date, const char* time);
-    DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time);
-    uint16_t year() const       { return 2000 + yOff; }
-    uint8_t month() const       { return m; }
-    uint8_t day() const         { return d; }
-    uint8_t hour() const        { return hh; }
-    uint8_t minute() const      { return mm; }
-    uint8_t second() const      { return ss; }
-    uint8_t dayOfTheWeek() const;
+  DateTime (uint32_t t = SECONDS_FROM_1970_TO_2000);
+  DateTime (uint16_t year, uint8_t month, uint8_t day,
+              uint8_t hour = 0, uint8_t min = 0, uint8_t sec = 0);
+  DateTime (const DateTime& copy);
+  DateTime (const char* date, const char* time);
+  DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time);
 
-    // 32-bit times as seconds since 1/1/2000
-    long secondstime() const;   
-    // 32-bit times as seconds since 1/1/1970
-    uint32_t unixtime(void) const;
-    
-    //ISO 8601 Timestamp function
-    enum timestampOpt{
-        TIMESTAMP_FULL, TIMESTAMP_TIME, TIMESTAMP_DATE
-    };
-    String timestamp(timestampOpt opt = TIMESTAMP_FULL);
+  /*!
+      @brief  Return the year, stored as an offset from 2000
+      @return uint16_t year
+  */
+  uint16_t year() const       { return 2000 + yOff; }
+  /*!
+      @brief  Return month
+      @return uint8_t month
+  */
+  uint8_t month() const       { return m; }
+  /*!
+      @brief  Return day
+      @return uint8_t day
+  */
+  uint8_t day() const         { return d; }
+  /*!
+      @brief  Return hours
+      @return uint8_t hours
+  */
+  uint8_t hour() const        { return hh; }
+  /*!
+      @brief  Return minutes
+      @return uint8_t minutes
+  */
+  uint8_t minute() const      { return mm; }
+  /*!
+      @brief  Return seconds
+      @return uint8_t seconds
+  */
+  uint8_t second() const      { return ss; }
 
-    DateTime operator+(const TimeSpan& span);
-    DateTime operator-(const TimeSpan& span);
-    TimeSpan operator-(const DateTime& right);
-    bool operator<(const DateTime& right) const;
-    bool operator>(const DateTime& right) const  { return right < *this; }
-    bool operator<=(const DateTime& right) const { return !(*this > right); }
-    bool operator>=(const DateTime& right) const { return !(*this < right); }
-    bool operator==(const DateTime& right) const;
-    bool operator!=(const DateTime& right) const { return !(*this == right); }
+  uint8_t dayOfTheWeek() const;
+
+  /** 32-bit times as seconds since 1/1/2000 */
+  long secondstime() const;
+
+  /** 32-bit times as seconds since 1/1/1970 */
+  uint32_t unixtime(void) const;
+
+  /** ISO 8601 Timestamp function */
+  enum timestampOpt{
+    TIMESTAMP_FULL, // YYYY-MM-DDTHH:MM:SS
+    TIMESTAMP_TIME, // HH:MM:SS
+    TIMESTAMP_DATE  // YYYY-MM-DD
+  };
+  String timestamp(timestampOpt opt = TIMESTAMP_FULL);
+
+  DateTime operator+(const TimeSpan& span);
+  DateTime operator-(const TimeSpan& span);
+  TimeSpan operator-(const DateTime& right);
+  bool operator<(const DateTime& right) const;
+  /*!
+      @brief  Test if one DateTime is greater (later) than another
+      @param right DateTime object to compare
+      @return True if the left object is greater than the right object, false otherwise
+  */
+  bool operator>(const DateTime& right) const  { return right < *this; }
+  /*!
+      @brief  Test if one DateTime is less (earlier) than or equal to another
+      @param right DateTime object to compare
+      @return True if the left object is less than or equal to the right object, false otherwise
+  */
+  bool operator<=(const DateTime& right) const { return !(*this > right); }
+  /*!
+      @brief  Test if one DateTime is greater (later) than or equal to another
+      @param right DateTime object to compare
+      @return True if the left object is greater than or equal to the right object, false otherwise
+  */
+  bool operator>=(const DateTime& right) const { return !(*this < right); }
+  bool operator==(const DateTime& right) const;
+  /*!
+      @brief  Test if two DateTime objects not equal
+      @param right DateTime object to compare
+      @return True if the two objects are not equal, false if they are
+  */
+  bool operator!=(const DateTime& right) const { return !(*this == right); }
 
 protected:
-    uint8_t yOff, m, d, hh, mm, ss;
+  uint8_t yOff;   ///< Year offset from 2000
+  uint8_t m;      ///< Month 1-12
+  uint8_t d;      ///< Day 1-31
+  uint8_t hh;     ///< Hours 0-23
+  uint8_t mm;     ///< Minutes 0-59
+  uint8_t ss;     ///< Seconds 0-59
 };
 
-// Timespan which can represent changes in time with seconds accuracy.
+
+/**************************************************************************/
+/*!
+    @brief  Timespan which can represent changes in time with seconds accuracy.
+*/
+/**************************************************************************/
 class TimeSpan {
 public:
-    TimeSpan (int32_t seconds = 0);
-    TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds);
-    TimeSpan (const TimeSpan& copy);
-    int16_t days() const         { return _seconds / 86400L; }
-    int8_t  hours() const        { return _seconds / 3600 % 24; }
-    int8_t  minutes() const      { return _seconds / 60 % 60; }
-    int8_t  seconds() const      { return _seconds % 60; }
-    int32_t totalseconds() const { return _seconds; }
+  TimeSpan (int32_t seconds = 0);
+  TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds);
+  TimeSpan (const TimeSpan& copy);
 
-    TimeSpan operator+(const TimeSpan& right);
-    TimeSpan operator-(const TimeSpan& right);
+  /*!
+      @brief  Number of days in the TimeSpan
+              e.g. 4
+      @return int16_t days
+  */
+  int16_t days() const         { return _seconds / 86400L; }
+  /*!
+      @brief  Number of hours in the TimeSpan
+              This is not the total hours, it includes the days
+              e.g. 4 days, 3 hours - NOT 99 hours
+      @return int8_t hours
+  */
+  int8_t  hours() const        { return _seconds / 3600 % 24; }
+  /*!
+      @brief  Number of minutes in the TimeSpan
+              This is not the total minutes, it includes days/hours
+              e.g. 4 days, 3 hours, 27 minutes
+      @return int8_t minutes
+  */
+  int8_t  minutes() const      { return _seconds / 60 % 60; }
+  /*!
+      @brief  Number of seconds in the TimeSpan
+              This is not the total seconds, it includes the days/hours/minutes
+              e.g. 4 days, 3 hours, 27 minutes, 7 seconds
+      @return int8_t seconds
+  */
+  int8_t  seconds() const      { return _seconds % 60; }
+  /*!
+      @brief  Total number of seconds in the TimeSpan, e.g. 358027
+      @return int32_t seconds
+  */
+  int32_t totalseconds() const { return _seconds; }
+
+  TimeSpan operator+(const TimeSpan& right);
+  TimeSpan operator-(const TimeSpan& right);
 
 protected:
-    int32_t _seconds;
+  int32_t _seconds;   ///< Actual TimeSpan value is stored as seconds
 };
 
-// RTC based on the DS1307 chip connected via I2C and the Wire library
-enum Ds1307SqwPinMode { OFF = 0x00, ON = 0x80, SquareWave1HZ = 0x10, SquareWave4kHz = 0x11, SquareWave8kHz = 0x12, SquareWave32kHz = 0x13 };
 
+
+/** DS1307 SQW pin mode settings */
+enum Ds1307SqwPinMode {
+  DS1307_OFF              = 0x00, // Low
+  DS1307_ON               = 0x80, // High
+  DS1307_SquareWave1HZ    = 0x10, // 1Hz square wave
+  DS1307_SquareWave4kHz   = 0x11, // 4kHz square wave
+  DS1307_SquareWave8kHz   = 0x12, // 8kHz square wave
+  DS1307_SquareWave32kHz  = 0x13  // 32kHz square wave
+};
+
+/**************************************************************************/
+/*!
+    @brief  RTC based on the DS1307 chip connected via I2C and the Wire library
+*/
+/**************************************************************************/
 class RTC_DS1307 {
 public:
-    boolean begin(void);
-    static void adjust(const DateTime& dt);
-    uint8_t isrunning(void);
-    static DateTime now();
-    static Ds1307SqwPinMode readSqwPinMode();
-    static void writeSqwPinMode(Ds1307SqwPinMode mode);
-    uint8_t readnvram(uint8_t address);
-    void readnvram(uint8_t* buf, uint8_t size, uint8_t address);
-    void writenvram(uint8_t address, uint8_t data);
-    void writenvram(uint8_t address, uint8_t* buf, uint8_t size);
+  boolean begin(void);
+  static void adjust(const DateTime& dt);
+  uint8_t isrunning(void);
+  static DateTime now();
+  static Ds1307SqwPinMode readSqwPinMode();
+  static void writeSqwPinMode(Ds1307SqwPinMode mode);
+  uint8_t readnvram(uint8_t address);
+  void readnvram(uint8_t* buf, uint8_t size, uint8_t address);
+  void writenvram(uint8_t address, uint8_t data);
+  void writenvram(uint8_t address, uint8_t* buf, uint8_t size);
 };
 
-// RTC based on the DS3231 chip connected via I2C and the Wire library
-enum Ds3231SqwPinMode { DS3231_OFF = 0x01, DS3231_SquareWave1Hz = 0x00, DS3231_SquareWave1kHz = 0x08, DS3231_SquareWave4kHz = 0x10, DS3231_SquareWave8kHz = 0x18 };
 
+
+/** DS3231 SQW pin mode settings */
+enum Ds3231SqwPinMode {
+  DS3231_OFF            = 0x01, // Off
+  DS3231_SquareWave1Hz  = 0x00, // 1Hz square wave
+  DS3231_SquareWave1kHz = 0x08, // 1kHz square wave
+  DS3231_SquareWave4kHz = 0x10, // 4kHz square wave
+  DS3231_SquareWave8kHz = 0x18  // 8kHz square wave
+};
+
+/**************************************************************************/
+/*!
+    @brief  RTC based on the DS3231 chip connected via I2C and the Wire library
+*/
+/**************************************************************************/
 class RTC_DS3231 {
 public:
-    boolean begin(void);
-    static void adjust(const DateTime& dt);
-    bool lostPower(void);
-    static DateTime now();
-    static Ds3231SqwPinMode readSqwPinMode();
-    static void writeSqwPinMode(Ds3231SqwPinMode mode);
-	static float getTemperature();		// in Celcius degree
+  boolean begin(void);
+  static void adjust(const DateTime& dt);
+  bool lostPower(void);
+  static DateTime now();
+  static Ds3231SqwPinMode readSqwPinMode();
+  static void writeSqwPinMode(Ds3231SqwPinMode mode);
+  static float getTemperature();  // in Celcius degree
 };
 
 
-// RTC based on the PCF8523 chip connected via I2C and the Wire library
-enum Pcf8523SqwPinMode { PCF8523_OFF = 7, PCF8523_SquareWave1HZ = 6, PCF8523_SquareWave32HZ = 5, PCF8523_SquareWave1kHz = 4, PCF8523_SquareWave4kHz = 3, PCF8523_SquareWave8kHz = 2, PCF8523_SquareWave16kHz = 1, PCF8523_SquareWave32kHz = 0 };
 
-enum Pcf8523OffsetMode { PCF8523_TwoHours = 0x00, PCF8523_OneMinute = 0x80 };
+/** PCF8523 SQW pin mode settings */
+enum Pcf8523SqwPinMode {
+  PCF8523_OFF             = 7, // Off
+  PCF8523_SquareWave1HZ   = 6, // 1Hz square wave
+  PCF8523_SquareWave32HZ  = 5, // 32Hz square wave
+  PCF8523_SquareWave1kHz  = 4, // 1kHz square wave
+  PCF8523_SquareWave4kHz  = 3, // 4kHz square wave
+  PCF8523_SquareWave8kHz  = 2, // 8kHz square wave
+  PCF8523_SquareWave16kHz = 1, // 16kHz square wave
+  PCF8523_SquareWave32kHz = 0  // 32kHz square wave
+};
 
+/** PCF8523 Offset modes for making temperature/aging/accuracy adjustments */
+enum Pcf8523OffsetMode {
+  PCF8523_TwoHours = 0x00,  // Offset made every two hours
+  PCF8523_OneMinute = 0x80  // Offset made every minute
+};
+
+/**************************************************************************/
+/*!
+    @brief  RTC based on the PCF8523 chip connected via I2C and the Wire library
+*/
+/**************************************************************************/
 class RTC_PCF8523 {
 public:
-    boolean begin(void);
-    void adjust(const DateTime& dt);
-    boolean initialized(void);
-    static DateTime now();
+  boolean begin(void);
+  void adjust(const DateTime& dt);
+  boolean initialized(void);
+  static DateTime now();
 
-    Pcf8523SqwPinMode readSqwPinMode();
-    void writeSqwPinMode(Pcf8523SqwPinMode mode);
-    void calibrate(Pcf8523OffsetMode mode, int8_t offset);
+  Pcf8523SqwPinMode readSqwPinMode();
+  void writeSqwPinMode(Pcf8523SqwPinMode mode);
+  void calibrate(Pcf8523OffsetMode mode, int8_t offset);
 };
 
-// RTC using the internal millis() clock, has to be initialized before use
-// NOTE: this is immune to millis() rollover events
+
+/**************************************************************************/
+/*!
+    @brief  RTC using the internal millis() clock, has to be initialized before use.
+            NOTE: this is immune to millis() rollover events.
+*/
+/**************************************************************************/
 class RTC_Millis {
 public:
-    static void begin(const DateTime& dt) { adjust(dt); }
-    static void adjust(const DateTime& dt);
-    static DateTime now();
+  /*!
+      @brief  Start the RTC
+      @param dt DateTime object with the date/time to set
+  */
+  static void begin(const DateTime& dt) { adjust(dt); }
+  static void adjust(const DateTime& dt);
+  static DateTime now();
 
 protected:
-    static uint32_t lastUnix;
-    static uint32_t lastMillis;
+  static uint32_t lastUnix;   ///< Unix time from the previous call to now() - prevents rollover issues
+  static uint32_t lastMillis; ///< the millis() value corresponding to the last **full second** of Unix time
 };
 
-// RTC using the internal micros() clock, has to be initialized before
-// use. Unlike RTC_Millis, this can be tuned in order to compensate for
-// the natural drift of the system clock. Note that now() has to be
-// called more frequently than the micros() rollover period, which is
-// approximately 71.6 minutes.
+
+
+/**************************************************************************/
+/*!
+    @brief  RTC using the internal micros() clock, has to be initialized before
+            use. Unlike RTC_Millis, this can be tuned in order to compensate for
+            the natural drift of the system clock. Note that now() has to be
+            called more frequently than the micros() rollover period, which is
+            approximately 71.6 minutes.
+*/
+/**************************************************************************/
 class RTC_Micros {
 public:
-    static void begin(const DateTime& dt) { adjust(dt); }
-    static void adjust(const DateTime& dt);
-    static void adjustDrift(int ppm);
-    static DateTime now();
+  /*!
+      @brief  Start the RTC
+      @param dt DateTime object with the date/time to set
+  */
+  static void begin(const DateTime& dt) { adjust(dt); }
+  static void adjust(const DateTime& dt);
+  static void adjustDrift(int ppm);
+  static DateTime now();
 
 protected:
-    static uint32_t microsPerSecond;
-    static uint32_t lastUnix;
-    static uint32_t lastMicros;
+  static uint32_t microsPerSecond;  ///< Number of microseconds reported by micros() per "true" (calibrated) second
+  static uint32_t lastUnix;         ///< Unix time from the previous call to now() - prevents rollover issues
+  static uint32_t lastMicros;       ///< micros() value corresponding to the last full second of Unix time
 };
 
 #endif // _RTCLIB_H_

--- a/examples/datecalc/datecalc.ino
+++ b/examples/datecalc/datecalc.ino
@@ -1,6 +1,5 @@
 // Simple date conversions and calculations
 
-#include <Wire.h>
 #include "RTClib.h"
 
 #if defined(ARDUINO_ARCH_SAMD)
@@ -22,13 +21,13 @@ void showDate(const char* txt, const DateTime& dt) {
     Serial.print(dt.minute(), DEC);
     Serial.print(':');
     Serial.print(dt.second(), DEC);
-    
+
     Serial.print(" = ");
     Serial.print(dt.unixtime());
     Serial.print("s / ");
     Serial.print(dt.unixtime() / 86400L);
     Serial.print("d since 1970");
-    
+
     Serial.println();
 }
 
@@ -54,7 +53,7 @@ void setup () {
   while (!Serial); // for Leonardo/Micro/Zero
 #endif
     Serial.begin(57600);
-    
+
     DateTime dt0 (0, 1, 1, 0, 0, 0);
     showDate("dt0", dt0);
 

--- a/examples/datecalc/datecalc.ino
+++ b/examples/datecalc/datecalc.ino
@@ -2,11 +2,6 @@
 
 #include "RTClib.h"
 
-#if defined(ARDUINO_ARCH_SAMD)
-// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
-   #define Serial SerialUSB
-#endif
-
 void showDate(const char* txt, const DateTime& dt) {
     Serial.print(txt);
     Serial.print(' ');

--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -1,5 +1,4 @@
 // Date and time functions using a DS1307 RTC connected via I2C and Wire lib
-#include <Wire.h>
 #include "RTClib.h"
 
 RTC_DS1307 rtc;
@@ -27,7 +26,7 @@ void setup () {
 
 void loop () {
     DateTime now = rtc.now();
-    
+
     Serial.print(now.year(), DEC);
     Serial.print('/');
     Serial.print(now.month(), DEC);
@@ -42,16 +41,16 @@ void loop () {
     Serial.print(':');
     Serial.print(now.second(), DEC);
     Serial.println();
-    
+
     Serial.print(" since midnight 1/1/1970 = ");
     Serial.print(now.unixtime());
     Serial.print("s = ");
     Serial.print(now.unixtime() / 86400L);
     Serial.println("d");
-    
+
     // calculate a date which is 7 days and 30 seconds into the future
     DateTime future (now + TimeSpan(7,12,30,6));
-    
+
     Serial.print(" now + 7d + 30s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
@@ -65,7 +64,7 @@ void loop () {
     Serial.print(':');
     Serial.print(future.second(), DEC);
     Serial.println();
-    
+
     Serial.println();
     delay(3000);
 }

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -13,11 +13,6 @@
 
 #include "RTClib.h"
 
-#if defined(ARDUINO_ARCH_SAMD)
-// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
-   #define Serial SerialUSB
-#endif
-
 RTC_DS1307 rtc;
 
 int mode_index = 0;

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -11,7 +11,6 @@
 // You must connect a pull up resistor (~10kohm) from the SQW pin up to VCC.  Without
 // this pull up the wave output will not work!
 
-#include <Wire.h>
 #include "RTClib.h"
 
 #if defined(ARDUINO_ARCH_SAMD)

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -23,21 +23,21 @@ RTC_DS1307 rtc;
 
 int mode_index = 0;
 
-Ds1307SqwPinMode modes[] = {OFF, ON, SquareWave1HZ, SquareWave4kHz, SquareWave8kHz, SquareWave32kHz};
+Ds1307SqwPinMode modes[] = { DS1307_OFF, DS1307_ON, DS1307_SquareWave1HZ, DS1307_SquareWave4kHz, DS1307_SquareWave8kHz, DS1307_SquareWave32kHz};
 
 
 void print_mode() {
   Ds1307SqwPinMode mode = rtc.readSqwPinMode();
-  
+
   Serial.print("Sqw Pin Mode: ");
   switch(mode) {
-  case OFF:             Serial.println("OFF");       break;
-  case ON:              Serial.println("ON");        break;
-  case SquareWave1HZ:   Serial.println("1Hz");       break;
-  case SquareWave4kHz:  Serial.println("4.096kHz");  break;
-  case SquareWave8kHz:  Serial.println("8.192kHz");  break;
-  case SquareWave32kHz: Serial.println("32.768kHz"); break;
-  default:              Serial.println("UNKNOWN");   break;
+  case DS1307_OFF:              Serial.println("OFF");       break;
+  case DS1307_ON:               Serial.println("ON");        break;
+  case DS1307_SquareWave1HZ:    Serial.println("1Hz");       break;
+  case DS1307_SquareWave4kHz:   Serial.println("4.096kHz");  break;
+  case DS1307_SquareWave8kHz:   Serial.println("8.192kHz");  break;
+  case DS1307_SquareWave32kHz:  Serial.println("32.768kHz"); break;
+  default:                      Serial.println("UNKNOWN");   break;
   }
 }
 

--- a/examples/ds1307nvram/ds1307nvram.ino
+++ b/examples/ds1307nvram/ds1307nvram.ino
@@ -4,11 +4,6 @@
 
 #include "RTClib.h"
 
-#if defined(ARDUINO_ARCH_SAMD)
-// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
-   #define Serial SerialUSB
-#endif
-
 RTC_DS1307 rtc;
 
 void printnvram(uint8_t address) {

--- a/examples/ds1307nvram/ds1307nvram.ino
+++ b/examples/ds1307nvram/ds1307nvram.ino
@@ -2,7 +2,6 @@
 // You can write up to 56 bytes from address 0 to 55.
 // Data will be persisted as long as the DS1307 has battery power.
 
-#include <Wire.h>
 #include "RTClib.h"
 
 #if defined(ARDUINO_ARCH_SAMD)
@@ -16,7 +15,7 @@ void printnvram(uint8_t address) {
   Serial.print("Address 0x");
   Serial.print(address, HEX);
   Serial.print(" = 0x");
-  Serial.println(rtc.readnvram(address), HEX); 
+  Serial.println(rtc.readnvram(address), HEX);
 }
 
 void setup () {
@@ -42,7 +41,7 @@ void setup () {
   // Example writing multiple bytes:
   uint8_t writeData[4] = { 0xBE, 0xEF, 0x01, 0x02 };
   rtc.writenvram(2, writeData, 4);
-  
+
   // Read bytes from non-volatile RAM storage.
   Serial.println("Reading NVRAM values:");
   // Example reading one byte at a time.
@@ -55,7 +54,7 @@ void setup () {
   Serial.println(readData[1], HEX);
   Serial.println(readData[2], HEX);
   Serial.println(readData[3], HEX);
-  
+
 }
 
 void loop () {

--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -1,5 +1,4 @@
 // Date and time functions using a DS3231 RTC connected via I2C and Wire lib
-#include <Wire.h>
 #include "RTClib.h"
 
 RTC_DS3231 rtc;
@@ -33,7 +32,7 @@ void setup () {
 
 void loop () {
     DateTime now = rtc.now();
-    
+
     Serial.print(now.year(), DEC);
     Serial.print('/');
     Serial.print(now.month(), DEC);
@@ -48,16 +47,16 @@ void loop () {
     Serial.print(':');
     Serial.print(now.second(), DEC);
     Serial.println();
-    
+
     Serial.print(" since midnight 1/1/1970 = ");
     Serial.print(now.unixtime());
     Serial.print("s = ");
     Serial.print(now.unixtime() / 86400L);
     Serial.println("d");
-    
+
     // calculate a date which is 7 days and 30 seconds into the future
     DateTime future (now + TimeSpan(7,12,30,6));
-    
+
     Serial.print(" now + 7d + 30s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
@@ -71,11 +70,11 @@ void loop () {
     Serial.print(':');
     Serial.print(future.second(), DEC);
     Serial.println();
-    
+
     Serial.print("Temperature: ");
     Serial.print(rtc.getTemperature());
     Serial.println(" C");
-    
+
     Serial.println();
     delay(3000);
 }

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -1,5 +1,4 @@
 // Date and time functions using a PCF8523 RTC connected via I2C and Wire lib
-#include <Wire.h>
 #include "RTClib.h"
 
 RTC_PCF8523 rtc;
@@ -30,7 +29,7 @@ void setup () {
 
 void loop () {
     DateTime now = rtc.now();
-    
+
     Serial.print(now.year(), DEC);
     Serial.print('/');
     Serial.print(now.month(), DEC);
@@ -45,16 +44,16 @@ void loop () {
     Serial.print(':');
     Serial.print(now.second(), DEC);
     Serial.println();
-    
+
     Serial.print(" since midnight 1/1/1970 = ");
     Serial.print(now.unixtime());
     Serial.print("s = ");
     Serial.print(now.unixtime() / 86400L);
     Serial.println("d");
-    
+
     // calculate a date which is 7 days, 12 hours and 30 seconds into the future
     DateTime future (now + TimeSpan(7,12,30,6));
-    
+
     Serial.print(" now + 7d + 12h + 30m + 6s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
@@ -68,7 +67,7 @@ void loop () {
     Serial.print(':');
     Serial.print(future.second(), DEC);
     Serial.println();
-    
+
     Serial.println();
     delay(3000);
 }

--- a/examples/softrtc/softrtc.ino
+++ b/examples/softrtc/softrtc.ino
@@ -1,7 +1,5 @@
 // Date and time functions using just software, based on millis() & timer
 
-#include <Arduino.h>
-#include <Wire.h>         // this #include still required because the RTClib depends on it
 #include "RTClib.h"
 
 #if defined(ARDUINO_ARCH_SAMD)
@@ -22,7 +20,7 @@ void setup () {
 
 void loop () {
     DateTime now = rtc.now();
-    
+
     Serial.print(now.year(), DEC);
     Serial.print('/');
     Serial.print(now.month(), DEC);
@@ -35,13 +33,13 @@ void loop () {
     Serial.print(':');
     Serial.print(now.second(), DEC);
     Serial.println();
-    
+
     Serial.print(" seconds since 1970: ");
     Serial.println(now.unixtime());
-    
+
     // calculate a date which is 7 days and 30 seconds into the future
     DateTime future (now.unixtime() + 7 * 86400L + 30);
-    
+
     Serial.print(" now + 7d + 30s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
@@ -55,7 +53,7 @@ void loop () {
     Serial.print(':');
     Serial.print(future.second(), DEC);
     Serial.println();
-    
+
     Serial.println();
     delay(3000);
 }

--- a/examples/softrtc/softrtc.ino
+++ b/examples/softrtc/softrtc.ino
@@ -2,11 +2,6 @@
 
 #include "RTClib.h"
 
-#if defined(ARDUINO_ARCH_SAMD)
-// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
-   #define Serial SerialUSB
-#endif
-
 RTC_Millis rtc;
 
 void setup () {

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -1,5 +1,5 @@
 /* Timestamp functions using a DS1307 RTC connected via I2C and Wire lib
-** 
+**
 ** Useful for file name
 **		` SD.open(time.timestamp()+".log", FILE_WRITE) `
 **
@@ -8,18 +8,12 @@
 ** Last Edit:
 */
 
-#include <Wire.h>
 #include "RTClib.h"
 
 RTC_DS1307 rtc;
 
 void setup() {
    Serial.begin(57600);
-#ifdef AVR
-  Wire.begin();
-#else
-  Wire1.begin(); // Shield I2C pins connect to alt I2C bus on Arduino Due
-#endif
   rtc.begin();
 
   if (! rtc.isrunning()) {
@@ -35,18 +29,18 @@ void setup() {
 
 void loop() {
  DateTime time = rtc.now();
- 
+
  //Full Timestamp
  Serial.println(String("DateTime::TIMESTAMP_FULL:\t")+time.timestamp(DateTime::TIMESTAMP_FULL));
- 
+
  //Date Only
  Serial.println(String("DateTime::TIMESTAMP_DATE:\t")+time.timestamp(DateTime::TIMESTAMP_DATE));
- 
+
  //Full Timestamp
  Serial.println(String("DateTime::TIMESTAMP_TIME:\t")+time.timestamp(DateTime::TIMESTAMP_TIME));
- 
+
  Serial.println("\n");
- 
+
  //Delay 5s
  delay(5000);
 }


### PR DESCRIPTION
Added doxygen documentation to RTClib

Prefixed DS1307 enums to avoid collisions with other libraries - previously they used the names ON and OFF which are commonly used elsewhere. See issues #83, #97 

Cleaned up the includes in examples, some were duplicating what's now done in RTClib cpp/h.