### PR TITLE
Make the Doxygen documentation more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a fork of JeeLab's fantastic real time clock library for Arduino.
 
-For details on using this library with an RTC module like the DS1307, PCF8523, or DS3231, see the guide at: https://learn.adafruit.com/ds1307-real-time-clock-breakout-board-kit/overview
+For a tutorial on using this library with an RTC module like the DS1307, PCF8523, or DS3231, see the guide at: https://learn.adafruit.com/ds1307-real-time-clock-breakout-board-kit/overview
+
+For the detailed API documentation, see https://adafruit.github.io/RTClib/html/index.html
 
 Works great with Adafruit RTC breakouts:
 

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -15,6 +15,23 @@
   please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
+  @section classes Available classes
+
+  This library provides the following classes:
+
+  - Classes for manipulating dates, times and durations:
+    - DateTime represents a specific point in time; this is the data
+      type used for setting and reading the supported RTCs
+    - TimeSpan represents the length of a time interval
+  - Interfacing specific RTC chips:
+    - RTC_DS1307
+    - RTC_DS3231
+    - RTC_PCF8523
+  - RTC emulated in software; do not expect much accuracy out of these:
+    - RTC_Millis is based on `millis()`
+    - RTC_Micros is based on `micros()`; its drift rate can be tuned by
+      the user
+
   @section license License
 
   Original library by JeeLabs http://news.jeelabs.org/code/, released to the public domain.


### PR DESCRIPTION
In order to make the [Doxygen documentation][doc] of this library easier to find and use, this pull request:

 - adds a link to it from the README
 - adds a high-level overview of the available classes to the Doxygen entry page

[doc]: https://adafruit.github.io/RTClib/html/index.html