### PR TITLE
Remove the last cell in the daysInMonth array

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -111,8 +111,12 @@ static void write_i2c_register(uint8_t addr, uint8_t reg, uint8_t val) {
 // utility code, some of this could be exposed in the DateTime API if needed
 /**************************************************************************/
 
-/** Number of days in each month */
-const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
+/**
+  Number of days in each month, from January to November. December is not
+  needed. Omitting it avoids an incompatibility with Paul Stoffregen's Time
+  library. C.f. https://github.com/adafruit/RTClib/issues/114
+*/
+const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30 };
 
 /**************************************************************************/
 /*!
@@ -172,7 +176,7 @@ DateTime::DateTime (uint32_t t) {
       break;
     days -= 365 + leap;
   }
-  for (m = 1; ; ++m) {
+  for (m = 1; m < 12; ++m) {
     uint8_t daysPerMonth = pgm_read_byte(daysInMonth + m - 1);
     if (leap && m == 2)
       ++daysPerMonth;


### PR DESCRIPTION
This is a proposed fix for issue #114: an incompatibility with Paul Stoffregen's Time library arising from both libraries defining identical arrays of constants.

It has been suggested to fix the issue by _adding_ a dummy entry at the end of the array, in order to make it different from the one in the Time library. However, the issue can also be fixed by _removing_ the last item from the array. This array is used in computations where the total number of days from the previous months in the year is added or subtracted from a day count. Since December is never among the previous months, the twelfth cell in the array is not useful.