### PR TITLE
Detect possible absence of DS3231 in begin()

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -943,13 +943,15 @@ void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
 
 /**************************************************************************/
 /*!
-    @brief  Start I2C for the DS3231
-    @return True
+    @brief  Start I2C for the DS3231 and test succesful connection
+    @return True if Wire can find DS3231 or false otherwise.
 */
 /**************************************************************************/
 boolean RTC_DS3231::begin(void) {
   Wire.begin();
-  return true;
+  Wire.beginTransmission (DS3231_ADDRESS);
+  if (Wire.endTransmission() == 0) return true;												
+  return false;
 }
 
 /**************************************************************************/


### PR DESCRIPTION
RTC_DS3231::begin now tests connection with DS3231 by using Wire.beginTransmission and Wire.endTransmission before returning true. Returns false is DS3231 is not found.

This solves https://github.com/adafruit/RTClib/issues/96

Changes were tested in AVR, ESP8266 and ESP32 cores without issues.