### PR TITLE
Add support for DS3231 alarms

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1078,6 +1078,14 @@ float RTC_DS3231::getTemperature()
   return (float) msb + (lsb >> 6) * 0.25f;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set alarm 1 for DS3231
+	@param 	dt DateTime object
+	@param 	alarm_mode, see Ds3231Alarm1Mode enum
+    @return False if control register is not set, otherwise true
+*/
+/**************************************************************************/
 bool RTC_DS3231::setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode) {
 	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
 	if (!(ctrl & 0x04)) {
@@ -1107,6 +1115,14 @@ bool RTC_DS3231::setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode) {
 	return true;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set alarm 2 for DS3231
+	@param 	dt DateTime object
+	@param 	alarm_mode, see Ds3231Alarm2Mode enum
+    @return False if control register is not set, otherwise true
+*/
+/**************************************************************************/
 bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
 	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
 	if (!(ctrl & 0x04)) {
@@ -1134,18 +1150,37 @@ bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
 	return true;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Disable alarm
+	@param 	alarm_num, alarm number to disable
+*/
+/**************************************************************************/
 void RTC_DS3231::disableAlarm(uint8_t alarm_num) {
 	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
 	ctrl &= ~(1 << (alarm_num - 1));
 	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Clear status of alarm
+	@param 	alarm_num, alarm number to clear
+*/
+/**************************************************************************/
 void RTC_DS3231::clearAlarm(uint8_t alarm_num) {
 	uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
 	status &= ~(0x1 << (alarm_num - 1));
 	write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get status of alarm
+	@param 	alarm_num, alarm number to disable
+	@return True if alarm has been fired otherwise false
+*/
+/**************************************************************************/
 bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 	uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
 	return (status >> (alarm_num - 1)) & 0x1;

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1104,6 +1104,7 @@ bool RTC_DS3231::setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode) {
 
 	ctrl |= 0x01; // AI1E
 	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
+	return true;
 }
 
 bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
@@ -1130,6 +1131,7 @@ bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
 
 	ctrl |= 0x02; // AI2E
 	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
+	return true;
 }
 
 void RTC_DS3231::disableAlarm(uint8_t alarm_num) {

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -972,7 +972,7 @@ bool RTC_DS3231::lostPower(void) {
 /**************************************************************************/
 void RTC_DS3231::adjust(const DateTime& dt) {
   Wire.beginTransmission(DS3231_ADDRESS);
-  Wire._I2C_WRITE((byte)0); // start at location 0
+  Wire._I2C_WRITE(DS3231_TIME); // start at location 0
   Wire._I2C_WRITE(bin2bcd(dt.second()));
   Wire._I2C_WRITE(bin2bcd(dt.minute()));
   Wire._I2C_WRITE(bin2bcd(dt.hour()));
@@ -1076,4 +1076,75 @@ float RTC_DS3231::getTemperature()
 //  Serial.println(lsb,HEX);
 
   return (float) msb + (lsb >> 6) * 0.25f;
+}
+
+bool RTC_DS3231::setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode) {
+	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
+	if (!(ctrl & 0x04)) {
+		return false;
+	}
+
+	uint8_t A1M1 = (alarm_mode & 0x01) << 7; // Seconds bit 7.
+	uint8_t A1M2 = (alarm_mode & 0x02) << 6; // Minutes bit 7.
+	uint8_t A1M3 = (alarm_mode & 0x04) << 5; // Hour bit 7.
+	uint8_t A1M4 = (alarm_mode & 0x08) << 4; // Day/Date bit 7.
+	uint8_t DY_DT = (alarm_mode & 0x10) << 2; // Day/Date bit 6. Date when 0, day of week when 1.
+
+	Wire.beginTransmission(DS3231_ADDRESS);
+	Wire._I2C_WRITE(DS3231_ALARM1);
+	Wire._I2C_WRITE(bin2bcd(dt.second()) | A1M1);
+	Wire._I2C_WRITE(bin2bcd(dt.minute()) | A1M2);
+	Wire._I2C_WRITE(bin2bcd(dt.hour()) | A1M3);
+	if (DY_DT) {
+		Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()) | A1M4 | DY_DT);
+	} else {
+		Wire._I2C_WRITE(bin2bcd(dt.day()) | A1M4 | DY_DT);
+	}
+	Wire.endTransmission();
+
+	ctrl |= 0x01; // AI1E
+	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
+}
+
+bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
+	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
+	if (!(ctrl & 0x04)) {
+		return false;
+	}
+
+	uint8_t A2M2 = (alarm_mode & 0x01) << 7; // Minutes bit 7.
+	uint8_t A2M3 = (alarm_mode & 0x02) << 6; // Hour bit 7.
+	uint8_t A2M4 = (alarm_mode & 0x04) << 5; // Day/Date bit 7.
+	uint8_t DY_DT = (alarm_mode & 0x8) << 3; // Day/Date bit 6. Date when 0, day of week when 1.
+
+	Wire.beginTransmission(DS3231_ADDRESS);
+	Wire._I2C_WRITE(DS3231_ALARM2);
+	Wire._I2C_WRITE(bin2bcd(dt.minute()) | A2M2);
+	Wire._I2C_WRITE(bin2bcd(dt.hour()) | A2M3);
+	if (DY_DT) {
+		Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()) | A2M4 | DY_DT);
+	} else {
+		Wire._I2C_WRITE(bin2bcd(dt.day()) | A2M4 | DY_DT);
+	}
+	Wire.endTransmission();
+
+	ctrl |= 0x02; // AI2E
+	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
+}
+
+void RTC_DS3231::disableAlarm(uint8_t alarm_num) {
+	uint8_t ctrl = read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL);
+	ctrl &= ~(1 << (alarm_num - 1));
+	write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
+}
+
+void RTC_DS3231::clearAlarm(uint8_t alarm_num) {
+	uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
+	status &= ~(0x1 << (alarm_num - 1));
+	write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
+}
+
+bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
+	uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
+	return (status >> (alarm_num - 1)) & 0x1;
 }

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1082,7 +1082,7 @@ float RTC_DS3231::getTemperature()
 /*!
     @brief  Set alarm 1 for DS3231
 	@param 	dt DateTime object
-	@param 	alarm_mode, see Ds3231Alarm1Mode enum
+	@param 	alarm_mode Desired mode, see Ds3231Alarm1Mode enum
     @return False if control register is not set, otherwise true
 */
 /**************************************************************************/
@@ -1119,7 +1119,7 @@ bool RTC_DS3231::setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode) {
 /*!
     @brief  Set alarm 2 for DS3231
 	@param 	dt DateTime object
-	@param 	alarm_mode, see Ds3231Alarm2Mode enum
+	@param 	alarm_mode Desired mode, see Ds3231Alarm2Mode enum
     @return False if control register is not set, otherwise true
 */
 /**************************************************************************/
@@ -1153,7 +1153,7 @@ bool RTC_DS3231::setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode) {
 /**************************************************************************/
 /*!
     @brief  Disable alarm
-	@param 	alarm_num, alarm number to disable
+	@param 	alarm_num Alarm number to disable
 */
 /**************************************************************************/
 void RTC_DS3231::disableAlarm(uint8_t alarm_num) {
@@ -1165,7 +1165,7 @@ void RTC_DS3231::disableAlarm(uint8_t alarm_num) {
 /**************************************************************************/
 /*!
     @brief  Clear status of alarm
-	@param 	alarm_num, alarm number to clear
+	@param 	alarm_num Alarm number to clear
 */
 /**************************************************************************/
 void RTC_DS3231::clearAlarm(uint8_t alarm_num) {
@@ -1177,7 +1177,7 @@ void RTC_DS3231::clearAlarm(uint8_t alarm_num) {
 /**************************************************************************/
 /*!
     @brief  Get status of alarm
-	@param 	alarm_num, alarm number to disable
+	@param 	alarm_num Alarm number to check status of
 	@return True if alarm has been fired otherwise false
 */
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -34,6 +34,9 @@ class TimeSpan;
 #define DS1307_NVRAM          0x08  ///< Start of RAM registers - 56 bytes, 0x08 to 0x3f
 
 #define DS3231_ADDRESS        0x68  ///< I2C address for DS3231
+#define DS3231_TIME           0x00
+#define DS3231_ALARM1         0x07
+#define DS3231_ALARM2         0x0B
 #define DS3231_CONTROL        0x0E  ///< Control register
 #define DS3231_STATUSREG      0x0F  ///< Status register
 #define DS3231_TEMPERATUREREG	0x11  ///< Temperature register (high byte - low byte is at 0x12), 10-bit temperature value
@@ -239,6 +242,22 @@ enum Ds3231SqwPinMode {
   DS3231_SquareWave8kHz = 0x18  // 8kHz square wave
 };
 
+enum Ds3231Alarm1Mode { 
+  DS3231_A1_PerSecond = 0x0F, 
+  DS3231_A1_Second = 0x0E, 
+  DS3231_A1_Minute = 0x0C, 
+  DS3231_A1_Hour = 0x08, 
+  DS3231_A1_Date = 0x00, 
+  DS3231_A1_Day = 0x10
+};
+enum Ds3231Alarm2Mode { 
+  DS3231_A2_PerMinute = 0x7, 
+  DS3231_A2_Minute = 0x6, 
+  DS3231_A2_Hour = 0x4, 
+  DS3231_A2_Date = 0x0, 
+  DS3231_A2_Day = 0x8 
+};
+
 /**************************************************************************/
 /*!
     @brief  RTC based on the DS3231 chip connected via I2C and the Wire library
@@ -252,6 +271,11 @@ public:
   static DateTime now();
   static Ds3231SqwPinMode readSqwPinMode();
   static void writeSqwPinMode(Ds3231SqwPinMode mode);
+  bool setAlarm1(const DateTime& dt, Ds3231Alarm1Mode alarm_mode);
+  bool setAlarm2(const DateTime& dt, Ds3231Alarm2Mode alarm_mode);
+  void disableAlarm(uint8_t alarm_num);
+  void clearAlarm(uint8_t alarm_num);
+  bool alarmFired(uint8_t alarm_num);
   static float getTemperature();  // in Celcius degree
 };
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -34,9 +34,9 @@ class TimeSpan;
 #define DS1307_NVRAM          0x08  ///< Start of RAM registers - 56 bytes, 0x08 to 0x3f
 
 #define DS3231_ADDRESS        0x68  ///< I2C address for DS3231
-#define DS3231_TIME           0x00
-#define DS3231_ALARM1         0x07
-#define DS3231_ALARM2         0x0B
+#define DS3231_TIME           0x00  ///< Time register
+#define DS3231_ALARM1         0x07  ///< Alarm 1 register
+#define DS3231_ALARM2         0x0B  ///< Alarm 2 register
 #define DS3231_CONTROL        0x0E  ///< Control register
 #define DS3231_STATUSREG      0x0F  ///< Status register
 #define DS3231_TEMPERATUREREG	0x11  ///< Temperature register (high byte - low byte is at 0x12), 10-bit temperature value
@@ -242,6 +242,7 @@ enum Ds3231SqwPinMode {
   DS3231_SquareWave8kHz = 0x18  // 8kHz square wave
 };
 
+/** DS3231 Alarm modes for alarm 1 */
 enum Ds3231Alarm1Mode { 
   DS3231_A1_PerSecond = 0x0F, 
   DS3231_A1_Second = 0x0E, 
@@ -250,6 +251,7 @@ enum Ds3231Alarm1Mode {
   DS3231_A1_Date = 0x00, 
   DS3231_A1_Day = 0x10
 };
+/** DS3231 Alarm modes for alarm 2 */
 enum Ds3231Alarm2Mode { 
   DS3231_A2_PerMinute = 0x7, 
   DS3231_A2_Minute = 0x6, 


### PR DESCRIPTION
Rebased with changes from #69 to add support for DS3231 alarms. Tested on a Feather M0 with DS3231 FeatherWing and the DS3231 breakout board. 