### PR TITLE
Fix Y2068 rollover in DateTime::secondstime()

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -148,8 +148,8 @@ static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {
     @return Number of seconds total
 */
 /**************************************************************************/
-static long time2long(uint16_t days, uint8_t h, uint8_t m, uint8_t s) {
-    return ((days * 24L + h) * 60 + m) * 60 + s;
+static uint32_t time2ulong(uint16_t days, uint8_t h, uint8_t m, uint8_t s) {
+    return ((days * 24UL + h) * 60 + m) * 60 + s;
 }
 
 
@@ -447,7 +447,7 @@ uint8_t DateTime::dayOfTheWeek() const {
 uint32_t DateTime::unixtime(void) const {
   uint32_t t;
   uint16_t days = date2days(yOff, m, d);
-  t = time2long(days, hh, mm, ss);
+  t = time2ulong(days, hh, mm, ss);
   t += SECONDS_FROM_1970_TO_2000;  // seconds from 1970 to 2000
 
   return t;
@@ -459,10 +459,10 @@ uint32_t DateTime::unixtime(void) const {
     @return The object as seconds since 2000-01-01
 */
 /**************************************************************************/
-long DateTime::secondstime(void) const {
-  long t;
+uint32_t DateTime::secondstime(void) const {
+  uint32_t t;
   uint16_t days = date2days(yOff, m, d);
-  t = time2long(days, hh, mm, ss);
+  t = time2ulong(days, hh, mm, ss);
   return t;
 }
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -106,7 +106,7 @@ public:
   uint8_t dayOfTheWeek() const;
 
   /** 32-bit times as seconds since 1/1/2000 */
-  long secondstime() const;
+  uint32_t secondstime() const;
 
   /** 32-bit times as seconds since 1/1/1970 */
   uint32_t unixtime(void) const;


### PR DESCRIPTION
As discussed in issue #146, the choice of `long` for the return type of `DateTime::secondstime()` creates a rollover issue on 2068-01-19. In order to extend the range of validity of the method, and for consistency with `unixtime()`, this pull request changes the return type to `uint32_t`.

The return type of the private function `time2long()` had to be changed in the same manner. It has then been renamed `time2ulong()`.

**Test sketch**:

```c++
#include <RTClib.h>

void print_time(uint16_t y, uint8_t m, uint8_t d) {
    DateTime t(y, m, d);
    Serial.print(t.timestamp(DateTime::TIMESTAMP_DATE));
    Serial.print("  ");
    Serial.println(2000 + t.secondstime() / (86400 * 365.25));
}

void setup() {
    Serial.begin(9600);
    Serial.println(" date     decimal year");
    Serial.println("----------------------");
    print_time(2000, 1,  1);
    print_time(2020, 4, 15);
    print_time(2068, 1, 19);
    print_time(2068, 1, 20);
    print_time(2100, 2, 28);
}

void loop(){}
```

**Output from the current master**:

```text
 date     decimal year
----------------------
2000-01-01  2000.00
2020-04-15  2020.29
2068-01-19  2068.05
2068-01-20  1931.95
2100-02-28  1964.06
```

**Output with this patch applied**:

```text
 date     decimal year
----------------------
2000-01-01  2000.00
2020-04-15  2020.29
2068-01-19  2068.05
2068-01-20  2068.05
2100-02-28  2100.16
```