### PR TITLE
Add new method DateTime::isValid()

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -213,10 +213,10 @@ DateTime::DateTime (uint32_t t) {
 /**************************************************************************/
 /*!
     @brief  Constructor from (year, month, day, hour, minute, second).
-
-    It is the responsibility of the user to ensure that the arguments are
-    valid.
-
+    @warning If the provided parameters are not valid (e.g. 31 February),
+           the constructed DateTime will be invalid.
+    @see   The `isValid()` method can be used to test whether the
+           constructed DateTime is valid.
     @param year Either the full year (range: 2000--2099) or the offset from
         year 2000 (range: 0--99).
     @param month Month number (1--12).
@@ -336,6 +336,19 @@ DateTime::DateTime (const __FlashStringHelper* date, const __FlashStringHelper* 
     hh = conv2d(buff);
     mm = conv2d(buff + 3);
     ss = conv2d(buff + 6);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Check whether this DateTime is valid.
+    @return true if valid, false if not.
+*/
+/**************************************************************************/
+bool DateTime::isValid() const {
+    if (yOff >= 100) return false;
+    DateTime other(unixtime());
+    return yOff==other.yOff && m==other.m && d==other.d
+           && hh==other.hh && mm==other.mm && ss==other.ss;
 }
 
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -70,6 +70,8 @@ public:
   DateTime (const DateTime& copy);
   DateTime (const char* date, const char* time);
   DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time);
+
+  bool isValid() const;
   char* toString(char* buffer);
 
   /*!


### PR DESCRIPTION
As mentioned in issue #127, the `DateTime` constructor that takes separate parameters for the year, month, etc. can easily build an invalid `DateTime` object. The library so far lacks a method for checking that the returned `DateTime` is valid.

This pull request adds such method. It is based on the concept that only a valid `DateTime` is invariant by conversion to Unix time and back. This `isValid()` method returns `false` for dates after 2099, as these are not officially supported by the library.

**Test sketch**:

```c++
#include <RTClib.h>

void check_time(uint16_t Y, uint8_t M, uint8_t D,
        uint8_t h, uint8_t m, uint8_t s) {
    DateTime t(Y, M, D, h, m, s);
    Serial.print(t.timestamp(DateTime::TIMESTAMP_FULL));
    Serial.print("  ");
    Serial.println(t.isValid() ? "yes" : "no");
}

void setup() {
    Serial.begin(9600);
    Serial.println("        date        valid?");
    Serial.println("--------------------------");
    check_time(2020,  4, 16, 23,  6, 34);
    check_time(2100,  4, 16, 23,  6, 34);
    check_time(2020, 12, 16, 23,  6, 34);
    check_time(2020, 13, 16, 23,  6, 34);
    check_time(2020,  4, 31, 23,  6, 34);
    check_time(2020,  4, 16, 25,  6, 34);
    check_time(2020,  4, 16, 23, 59, 34);
    check_time(2020,  4, 16, 23, 60, 34);
    check_time(2020,  4, 16, 23,  6, 59);
    check_time(2020,  4, 16, 23,  6, 60);
}

void loop(){}
```

**Output**:

```text
        date        valid?
--------------------------
2020-04-16T23:06:34  yes
2100-04-16T23:06:34  no
2020-12-16T23:06:34  yes
2020-13-16T23:06:34  no
2020-04-31T23:06:34  no
2020-04-16T25:06:34  no
2020-04-16T23:59:34  yes
2020-04-16T23:60:34  no
2020-04-16T23:06:59  yes
2020-04-16T23:06:60  no
```