### PR TITLE
Fix signed/unsigned compare warnings

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -194,7 +194,7 @@ DateTime::DateTime(uint32_t t) {
   uint8_t leap;
   for (yOff = 0;; ++yOff) {
     leap = yOff % 4 == 0;
-    if (days < 365 + leap)
+    if (days < 365U + leap)
       break;
     days -= 365 + leap;
   }
@@ -448,7 +448,7 @@ char *DateTime::toString(char *buffer) {
     }
   }
 
-  for (int i = 0; i < strlen(buffer) - 1; i++) {
+  for (size_t i = 0; i < strlen(buffer) - 1; i++) {
     if (buffer[i] == 'h' && buffer[i + 1] == 'h') {
       if (!apTag) { // 24 Hour Mode
         buffer[i] = '0' + hh / 10;


### PR DESCRIPTION
This pull request fixes a couple of "comparison between signed and unsigned integer expressions" warnings:

```text
RTClib.cpp: In constructor 'DateTime::DateTime(uint32_t)':
RTClib.cpp:197:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (days < 365 + leap)
         ~~~~~^~~~~~~~~~~~
RTClib.cpp: In member function 'char* DateTime::toString(char*)':
RTClib.cpp:451:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < strlen(buffer) - 1; i++) {
                   ~~^~~~~~~~~~~~~~~~~~~~
```

The first warning has been reported on Aug 2018 as issue #99. The other one is more recent, presumably introduced on Jul 2019 by commit 24d13d64eaf68c0febf6ed93915367b6b1eeb876.

This PR partially overlaps with PR #109, opened on Feb 2019 and closed today. That PR, however, addresses other unrelated issues and does not fix the second warning (which is younger than the PR).