### PR TITLE
Fix JeeLabs link, remove OneWire dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Adafruit invests time and resources providing this open source code, please supp
 
 # Dependencies
  * [TinyWireM](https://github.com/adafruit/TinyWireM)
- * [OneWire](https://github.com/PaulStoffregen/OneWire)
 
 # Contributing
 

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -35,7 +35,7 @@
 
   @section license License
 
-  Original library by JeeLabs http://news.jeelabs.org/code/, released to the
+  Original library by JeeLabs https://jeelabs.org/pub/docs/rtclib/, released to the
   public domain.
 
   This version: MIT (see LICENSE)

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -35,8 +35,8 @@
 
   @section license License
 
-  Original library by JeeLabs https://jeelabs.org/pub/docs/rtclib/, released to the
-  public domain.
+  Original library by JeeLabs https://jeelabs.org/pub/docs/rtclib/, released to
+  the public domain.
 
   This version: MIT (see LICENSE)
 */

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=A fork of Jeelab's fantastic RTC library
 category=Timing
 url=https://github.com/adafruit/RTClib
 architectures=*
-depends=TinyWireM, OneWire
+depends=TinyWireM


### PR DESCRIPTION
Fixes the old link to JeeLabs RTClib (#60) and removes the incorrect OneWire dependency.