### PR TITLE
Fix examples to start Serial before checking for USB connection.

### DIFF
--- a/examples/datecalc/datecalc.ino
+++ b/examples/datecalc/datecalc.ino
@@ -43,11 +43,11 @@ void showTimeSpan(const char* txt, const TimeSpan& ts) {
 }
 
 void setup () {
+    Serial.begin(57600);
 
 #ifndef ESP8266
-  while (!Serial); // for Leonardo/Micro/Zero
+    while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
-    Serial.begin(57600);
 
     DateTime dt0 (0, 1, 1, 0, 0, 0);
     showDate("dt0", dt0);

--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -6,9 +6,12 @@ RTC_DS1307 rtc;
 char daysOfTheWeek[7][12] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
 void setup () {
-  while (!Serial); // for Leonardo/Micro/Zero
-
   Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     while (1);

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -36,12 +36,12 @@ void print_mode() {
 }
 
 void setup () {
+  Serial.begin(57600);
 
 #ifndef ESP8266
-  while (!Serial); // for Leonardo/Micro/Zero
+  while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
 
-  Serial.begin(57600);
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     while (1);

--- a/examples/ds1307nvram/ds1307nvram.ino
+++ b/examples/ds1307nvram/ds1307nvram.ino
@@ -14,11 +14,12 @@ void printnvram(uint8_t address) {
 }
 
 void setup () {
+  Serial.begin(57600);
 
 #ifndef ESP8266
-  while (!Serial); // for Leonardo/Micro/Zero
+  while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
-  Serial.begin(57600);
+
   rtc.begin();
 
   // Print old RAM contents on startup.

--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -6,14 +6,11 @@ RTC_DS3231 rtc;
 char daysOfTheWeek[7][12] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
 void setup () {
+  Serial.begin(57600);
 
 #ifndef ESP8266
-  while (!Serial); // for Leonardo/Micro/Zero
+  while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
-
-  Serial.begin(9600);
-
-  delay(3000); // wait for console opening
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
@@ -28,7 +25,7 @@ void setup () {
     // January 21, 2014 at 3am you would call:
     // rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));
   }
-  
+
   // If you need to set the time of the uncomment line 34 or 37
   // following line sets the RTC to the date & time this sketch was compiled
   // rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -6,12 +6,12 @@ RTC_PCF8523 rtc;
 char daysOfTheWeek[7][12] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
 void setup () {
-
-  while (!Serial) {
-    delay(1);  // for Leonardo/Micro/Zero
-  }
-
   Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     while (1);

--- a/examples/softrtc/softrtc.ino
+++ b/examples/softrtc/softrtc.ino
@@ -6,6 +6,11 @@ RTC_Millis rtc;
 
 void setup () {
     Serial.begin(57600);
+
+#ifndef ESP8266
+    while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
     // following line sets the RTC to the date & time this sketch was compiled
     rtc.begin(DateTime(F(__DATE__), F(__TIME__)));
     // This line sets the RTC with an explicit date & time, for example to set

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -13,7 +13,12 @@
 RTC_DS1307 rtc;
 
 void setup() {
-   Serial.begin(57600);
+  Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
   rtc.begin();
 
   if (! rtc.isrunning()) {

--- a/examples/toString/toString.ino
+++ b/examples/toString/toString.ino
@@ -1,13 +1,16 @@
 #include <Wire.h>
 #include <RTClib.h>
 
-RTC_DS1307 rtc; 
+RTC_DS1307 rtc;
 
 
 void setup() {
-  while (!Serial); // for Leonardo/Micro/Zero
-
   Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     while (1);
@@ -19,16 +22,16 @@ void setup() {
     rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
     // This line sets the RTC with an explicit date & time, for example to set
     // January 21, 2014 at 3am you would call:
-    // rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));  
-  }    
+    // rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));
+  }
 }
 
 void loop() {
-    
+
    DateTime now = rtc.now();
-  
+
   //buffer can be defined using following combinations:
-  //hh - the hour with a leading zero (00 to 23) 
+  //hh - the hour with a leading zero (00 to 23)
   //mm - the minute with a leading zero (00 to 59)
   //ss - the whole second with a leading zero where applicable (00 to 59)
   //YYYY - the year as four digit number
@@ -37,16 +40,16 @@ void loop() {
   //MMM - the abbreviated English month name ('Jan' to 'Dec')
   //DD - the day as number with a leading zero (01 to 31)
   //DDD - the abbreviated English day name ('Mon' to 'Sun')
-  
+
    char buf1[] = "hh:mm";
    Serial.println(now.toString(buf1));
 
    char buf2[] = "YYMMDD-hh:mm:ss";
    Serial.println(now.toString(buf2));
-   
+
    char buf3[] = "Today is DDD, MMM DD YYYY";
    Serial.println(now.toString(buf3));
-   
+
    char buf4[] = "MM-DD-YYYY";
    Serial.println(now.toString(buf4));
 


### PR DESCRIPTION
Prompted by RTClib issue #137 for PCF8523.ino, but upon inspection, all of the RTClib examples that waited for a native USB connection were checking Serial status before it was actually started.

Further, some examples exempted ESP8266 from the Serial check, others did not have a check at all.

This change standardizes the Serial opening steps across all RTClib examples.

Tested on:
Feather M4 Express w/DS1307
Feather M4 Express w/PCF8523
Feather nRF52840 Sense w/DS1307
Feather nRF52840 Sense w/PCF8523

(in the case of the DS1307, 5v power was supplied, with SDA/SCL pulled up to Feather's 3v supply)

Unfortunately, I do not have an ESP8266 or DS3231 to test with. However, all examples connected to the Arduino IDE built-in Serial monitor without issue.

Useful reference: https://www.arduino.cc/reference/en/language/functions/communication/serial/ifserial

Resolves #137


Personal note - I'm new to this community but excited to contribute. I appreciate your review and welcome your feedback!