### PR TITLE
Fix for DS3231 readSqwPinMode and century bit

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1193,7 +1193,7 @@ DateTime RTC_DS3231::now() {
   uint8_t hh = bcd2bin(Wire._I2C_READ());
   Wire._I2C_READ();
   uint8_t d = bcd2bin(Wire._I2C_READ());
-  uint8_t m = bcd2bin(Wire._I2C_READ());
+  uint8_t m = bcd2bin(Wire._I2C_READ() & 0x7F);
   uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000;
 
   return DateTime(y, m, d, hh, mm, ss);

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1215,7 +1215,10 @@ Ds3231SqwPinMode RTC_DS3231::readSqwPinMode() {
   Wire.requestFrom((uint8_t)DS3231_ADDRESS, (uint8_t)1);
   mode = Wire._I2C_READ();
 
-  mode &= 0x93;
+  mode &= 0x1C;
+  if (mode & 0x04) {
+      mode = DS3231_OFF;
+  }
   return static_cast<Ds3231SqwPinMode>(mode);
 }
 

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1217,7 +1217,7 @@ Ds3231SqwPinMode RTC_DS3231::readSqwPinMode() {
 
   mode &= 0x1C;
   if (mode & 0x04) {
-      mode = DS3231_OFF;
+    mode = DS3231_OFF;
   }
   return static_cast<Ds3231SqwPinMode>(mode);
 }

--- a/examples/ds3231SqwPin/ds3231SqwPin.ino
+++ b/examples/ds3231SqwPin/ds3231SqwPin.ino
@@ -1,0 +1,48 @@
+#include "RTClib.h"
+
+RTC_DS3231 rtc;
+
+int mode_index = 0;
+
+Ds3231SqwPinMode modes[] = { DS3231_OFF, DS3231_SquareWave1Hz,
+  DS3231_SquareWave1kHz, DS3231_SquareWave4kHz, DS3231_SquareWave8kHz };
+
+void print_mode() {
+  Ds3231SqwPinMode mode = rtc.readSqwPinMode();
+
+  Serial.print("Sqw Pin Mode: ");
+  switch(mode) {
+    case DS3231_OFF:              Serial.println("OFF");       break;
+    case DS3231_SquareWave1Hz:    Serial.println("1Hz");       break;
+    case DS3231_SquareWave1kHz:   Serial.println("1.024kHz");  break;
+    case DS3231_SquareWave4kHz:   Serial.println("4.096kHz");  break;
+    case DS3231_SquareWave8kHz:   Serial.println("8.192kHz");  break;
+    default:                      Serial.println("UNKNOWN");   break;
+  }
+}
+
+void setup () {
+  Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // for Leonardo/Micro/Zero
+#endif
+
+  if (! rtc.begin()) {
+    Serial.println("Couldn't find RTC");
+    while (1);
+  }
+
+  print_mode();
+}
+
+void loop () {
+  rtc.writeSqwPinMode(modes[mode_index++]);
+  print_mode();
+
+  if (mode_index > 4) {
+    mode_index = 0;
+  }
+
+  delay(5000);
+}


### PR DESCRIPTION
This fixes #71 by ignoring the century bit in the month register which could have caused problems if it overflowed or was set by something else (e.g. RPi) and then used with this library.

Fixes #81 and #88 by using the correct mask for readSqwPinMode() and includes an example to test it out.