### PR TITLE
Added option to use SBWIRE to avoid well-known I2C hangup problems with Wire lib

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -46,7 +46,7 @@
 #ifdef __AVR_ATtiny85__
 #include <TinyWireM.h>
 #define Wire TinyWireM
-#elif defined USE_SBWIRE //Uncomment #define in RTClib.h to fix I2C lockups
+#elif defined USE_SBWIRE // Uncomment #define in RTClib.h to fix I2C lockups
 #include <SBWire.h>
 #else
 #include <Wire.h>

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -46,7 +46,7 @@
 #ifdef __AVR_ATtiny85__
 #include <TinyWireM.h>
 #define Wire TinyWireM
-#elif defined USE_SBWIRE //Uncomment this definition in RTClib.h to avoid Wire library lockups
+#elif defined USE_SBWIRE //Uncomment #define in RTClib.h to fix I2C lockups
 #include <SBWire.h>
 #else
 #include <Wire.h>

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -41,15 +41,17 @@
   This version: MIT (see LICENSE)
 */
 /**************************************************************************/
+#include "RTClib.h"
 
 #ifdef __AVR_ATtiny85__
 #include <TinyWireM.h>
 #define Wire TinyWireM
+#elif defined USE_SBWIRE //Uncomment this definition in RTClib.h to avoid Wire library lockups
+#include <SBWire.h>
 #else
 #include <Wire.h>
 #endif
 
-#include "RTClib.h"
 #ifdef __AVR__
 #include <avr/pgmspace.h>
 #elif defined(ESP8266)

--- a/RTClib.h
+++ b/RTClib.h
@@ -25,7 +25,7 @@
 #include <Arduino.h>
 class TimeSpan;
 
-#define USE_SBWIRE //uncomment this to use SBWire, which fixes Wire library lockup problems
+//#define USE_SBWIRE //uncomment this to use SBWire, which fixes Wire library lockup problems
 
 
 /** Registers */

--- a/RTClib.h
+++ b/RTClib.h
@@ -25,6 +25,9 @@
 #include <Arduino.h>
 class TimeSpan;
 
+#define USE_SBWIRE //uncomment this to use SBWire, which fixes Wire library lockup problems
+
+
 /** Registers */
 #define PCF8523_ADDRESS 0x68       ///< I2C address for PCF8523
 #define PCF8523_CLKOUTCONTROL 0x0F ///< Timer and CLKOUT control register

--- a/RTClib.h
+++ b/RTClib.h
@@ -26,7 +26,7 @@
 class TimeSpan;
 
 // uncomment next line to use SBWire, which fixes Wire library lockup problems
-//#define USE_SBWIRE 
+//#define USE_SBWIRE
 
 /** Registers */
 #define PCF8523_ADDRESS 0x68       ///< I2C address for PCF8523

--- a/RTClib.h
+++ b/RTClib.h
@@ -25,8 +25,8 @@
 #include <Arduino.h>
 class TimeSpan;
 
-//#define USE_SBWIRE //uncomment this to use SBWire, which fixes Wire library lockup problems
-
+//uncomment next line to use SBWire, which fixes Wire library lockup problems
+//#define USE_SBWIRE 
 
 /** Registers */
 #define PCF8523_ADDRESS 0x68       ///< I2C address for PCF8523

--- a/RTClib.h
+++ b/RTClib.h
@@ -25,7 +25,7 @@
 #include <Arduino.h>
 class TimeSpan;
 
-//uncomment next line to use SBWire, which fixes Wire library lockup problems
+// uncomment next line to use SBWire, which fixes Wire library lockup problems
 //#define USE_SBWIRE 
 
 /** Registers */


### PR DESCRIPTION
The Arduino Wire library has a well-known hangup problem where blocking read & write calls never return. SBWire adds timeouts to all potentially blocking calls.  This pull request simply adds the option to switch from the Wire library to SBWIRE.

Note that I submitted this request Feb 17, 2019 but it never got merged.