### PR TITLE
Add countdown timer support for PCF8523, and an example.

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1086,8 +1086,8 @@ DateTime RTC_PCF8523::now() {
 
 /**************************************************************************/
 /*!
-    @brief  Read the mode of the SQW pin on the PCF8523
-    @return SQW pin mode as a Pcf8523SqwPinMode enum
+    @brief  Read the mode of the INT/SQW pin on the PCF8523
+    @return SQW pin mode as a #Pcf8523SqwPinMode enum
 */
 /**************************************************************************/
 Pcf8523SqwPinMode RTC_PCF8523::readSqwPinMode() {
@@ -1107,25 +1107,144 @@ Pcf8523SqwPinMode RTC_PCF8523::readSqwPinMode() {
 
 /**************************************************************************/
 /*!
-    @brief  Set the SQW pin mode on the PCF8523
-    @param mode The mode to set, see the Pcf8523SqwPinMode enum for options
+    @brief  Set the INT/SQW pin mode on the PCF8523
+    @param mode The mode to set, see the #Pcf8523SqwPinMode enum for options
 */
 /**************************************************************************/
 void RTC_PCF8523::writeSqwPinMode(Pcf8523SqwPinMode mode) {
   Wire.beginTransmission(PCF8523_ADDRESS);
   Wire._I2C_WRITE(PCF8523_CLKOUTCONTROL);
-  Wire._I2C_WRITE(mode << 3);
+  Wire._I2C_WRITE(mode << 3); // disables other timers
   Wire.endTransmission();
 }
 
 /**************************************************************************/
 /*!
-    @brief  Use an offset to calibrate the PCF8523. This can be used for:
+    @brief  Enable the Second Timer (1Hz) Interrupt on the PCF8523.
+    @details The INT/SQW pin will pull low for a brief pulse once per second.
+*/
+/**************************************************************************/
+void RTC_PCF8523::enableSecondTimer() {
+  // Leave compatible settings intact
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
+  uint8_t clkreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL);
+
+  // TAM pulse int. mode (shared with Timer A), CLKOUT (aka SQW) disabled
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL, clkreg | 0xB8);
+
+  // SIE Second timer int. enable
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg | (1 << 2));
+}
+
+/**************************************************************************/
+/*!
+    @brief  Disable the Second Timer (1Hz) Interrupt on the PCF8523.
+*/
+/**************************************************************************/
+void RTC_PCF8523::disableSecondTimer() {
+  // Leave compatible settings intact
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
+
+  // SIE Second timer int. disable
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg & ~(1 << 2));
+}
+
+/**************************************************************************/
+/*!
+    @brief  Enable the Countdown Timer Interrupt on the PCF8523.
+    @details The INT/SQW pin will be pulled low at the end of a specified
+   countdown period ranging from 244 microseconds to 10.625 days.
+    Uses PCF8523 Timer B. Any existing CLKOUT square wave, configured with
+   writeSqwPinMode(), will halt. The interrupt low pulse width is adjustable
+   from 3/64ths (default) to 14/64ths of a second.
+    @param clkFreq One of the PCF8523's Timer Source Clock Frequencies.
+   See the #PCF8523TimerClockFreq enum for options and associated time ranges.
+    @param numPeriods The number of clkFreq periods (1-255) to count down.
+    @param lowPulseWidth Optional: the length of time for the interrupt pin
+   low pulse. See the #PCF8523TimerIntPulse enum for options.
+*/
+/**************************************************************************/
+void RTC_PCF8523::enableCountdownTimer(PCF8523TimerClockFreq clkFreq,
+                                       uint8_t numPeriods,
+                                       uint8_t lowPulseWidth) {
+  // Datasheet cautions against updating countdown value while it's running,
+  // so disabling allows repeated calls with new values to set new countdowns
+  disableCountdownTimer();
+
+  // Leave compatible settings intact
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_2);
+  uint8_t clkreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL);
+
+  // CTBIE Countdown Timer B Interrupt Enabled
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_2, ctlreg |= 0x01);
+
+  // Timer B source clock frequency, optionally int. low pulse width
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_TIMER_B_FRCTL,
+                     lowPulseWidth << 4 | clkFreq);
+
+  // Timer B value (number of source clock periods)
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_TIMER_B_VALUE, numPeriods);
+
+  // TBM Timer B pulse int. mode, CLKOUT (aka SQW) disabled, TBC start Timer B
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL, clkreg | 0x79);
+}
+
+/**************************************************************************/
+/*!
+    @overload
+    @brief  Enable Countdown Timer using default interrupt low pulse width.
+*/
+/**************************************************************************/
+void RTC_PCF8523::enableCountdownTimer(PCF8523TimerClockFreq clkFreq,
+                                       uint8_t numPeriods) {
+  enableCountdownTimer(clkFreq, numPeriods, 0);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Disable the Countdown Timer Interrupt on the PCF8523.
+    @details For simplicity, this function strictly disables Timer B by setting
+   TBC to 0. The datasheet describes TBC as the Timer B on/off switch.
+   Timer B is the only countdown timer implemented at this time.
+   The following flags have no effect while TBC is off, they are *not* cleared:
+      - TBM: Timer B will still be set to pulsed mode.
+      - CTBIE: Timer B interrupt would be triggered if TBC were on.
+      - CTBF: Timer B flag indicates that interrupt was triggered. Though
+        typically used for non-pulsed mode, user may wish to query this later.
+*/
+/**************************************************************************/
+void RTC_PCF8523::disableCountdownTimer() {
+  // Leave compatible settings intact
+  uint8_t clkreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL);
+
+  // TBC disable to stop Timer B clock
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL, ~1 & clkreg);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Stop all timers, clear their flags and settings on the PCF8523.
+    @details This includes the Countdown Timer, Second Timer, and any CLKOUT
+   square wave configured with writeSqwPinMode().
+*/
+/**************************************************************************/
+void RTC_PCF8523::deconfigureAllTimers() {
+  disableSecondTimer(); // Surgically clears CONTROL_1
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_2, 0);
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_CLKOUTCONTROL, 0);
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_TIMER_B_FRCTL, 0);
+  write_i2c_register(PCF8523_ADDRESS, PCF8523_TIMER_B_VALUE, 0);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Use an offset to calibrate the PCF8523.
+    @details This can be used for:
             - Aging adjustment
             - Temperature compensation
             - Accuracy tuning
     @param mode The offset mode to use, once every two hours or once every
-   minute. See the Pcf8523OffsetMode enum.
+   minute. See the #Pcf8523OffsetMode enum.
     @param offset Offset value from -64 to +63. See the datasheet for exact ppm
    values.
 */

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1193,6 +1193,9 @@ void RTC_PCF8523::enableCountdownTimer(PCF8523TimerClockFreq clkFreq,
 /*!
     @overload
     @brief  Enable Countdown Timer using default interrupt low pulse width.
+    @param clkFreq One of the PCF8523's Timer Source Clock Frequencies.
+   See the #PCF8523TimerClockFreq enum for options and associated time ranges.
+    @param numPeriods The number of clkFreq periods (1-255) to count down.
 */
 /**************************************************************************/
 void RTC_PCF8523::enableCountdownTimer(PCF8523TimerClockFreq clkFreq,

--- a/RTClib.h
+++ b/RTClib.h
@@ -28,7 +28,11 @@ class TimeSpan;
 /** Registers */
 #define PCF8523_ADDRESS 0x68       ///< I2C address for PCF8523
 #define PCF8523_CLKOUTCONTROL 0x0F ///< Timer and CLKOUT control register
+#define PCF8523_CONTROL_1 0x00     ///< Control and status register 1
+#define PCF8523_CONTROL_2 0x01     ///< Control and status register 2
 #define PCF8523_CONTROL_3 0x02     ///< Control and status register 3
+#define PCF8523_TIMER_B_FRCTL 0x12 ///< Timer B source clock frequency control
+#define PCF8523_TIMER_B_VALUE 0x13 ///< Timer B value (number clock periods)
 #define PCF8523_OFFSET 0x0E        ///< Offset register
 #define PCF8523_STATUSREG 0x03     ///< Status register
 
@@ -305,22 +309,45 @@ public:
   static float getTemperature(); // in Celcius degree
 };
 
-/** PCF8523 SQW pin mode settings */
+/** PCF8523 INT/SQW pin mode settings */
 enum Pcf8523SqwPinMode {
-  PCF8523_OFF = 7,             // Off
-  PCF8523_SquareWave1HZ = 6,   // 1Hz square wave
-  PCF8523_SquareWave32HZ = 5,  // 32Hz square wave
-  PCF8523_SquareWave1kHz = 4,  // 1kHz square wave
-  PCF8523_SquareWave4kHz = 3,  // 4kHz square wave
-  PCF8523_SquareWave8kHz = 2,  // 8kHz square wave
-  PCF8523_SquareWave16kHz = 1, // 16kHz square wave
-  PCF8523_SquareWave32kHz = 0  // 32kHz square wave
+  PCF8523_OFF = 7,             /**< Off */
+  PCF8523_SquareWave1HZ = 6,   /**< 1Hz square wave */
+  PCF8523_SquareWave32HZ = 5,  /**< 32Hz square wave */
+  PCF8523_SquareWave1kHz = 4,  /**< 1kHz square wave */
+  PCF8523_SquareWave4kHz = 3,  /**< 4kHz square wave */
+  PCF8523_SquareWave8kHz = 2,  /**< 8kHz square wave */
+  PCF8523_SquareWave16kHz = 1, /**< 16kHz square wave */
+  PCF8523_SquareWave32kHz = 0  /**< 32kHz square wave */
+};
+
+/** PCF8523 Timer Source Clock Frequencies for Timers A and B */
+enum PCF8523TimerClockFreq {
+  PCF8523_Frequency4kHz = 0,   /**< 1/4096th second = 244 microseconds,
+                                    max 62.256 milliseconds */
+  PCF8523_Frequency64Hz = 1,   /**< 1/64th second = 15.625 milliseconds,
+                                    max 3.984375 seconds */
+  PCF8523_FrequencySecond = 2, /**< 1 second, max 255 seconds = 4.25 minutes */
+  PCF8523_FrequencyMinute = 3, /**< 1 minute, max 255 minutes = 4.25 hours */
+  PCF8523_FrequencyHour = 4,   /**< 1 hour, max 255 hours = 10.625 days */
+};
+
+/** PCF8523 Timer Interrupt Low Pulse Width options for Timer B only */
+enum PCF8523TimerIntPulse {
+  PCF8523_LowPulse3x64Hz = 0,  /**<  46.875 ms   3/64ths second */
+  PCF8523_LowPulse4x64Hz = 1,  /**<  62.500 ms   4/64ths second */
+  PCF8523_LowPulse5x64Hz = 2,  /**<  78.125 ms   5/64ths second */
+  PCF8523_LowPulse6x64Hz = 3,  /**<  93.750 ms   6/64ths second */
+  PCF8523_LowPulse8x64Hz = 4,  /**< 125.000 ms   8/64ths second */
+  PCF8523_LowPulse10x64Hz = 5, /**< 156.250 ms  10/64ths second */
+  PCF8523_LowPulse12x64Hz = 6, /**< 187.500 ms  12/64ths second */
+  PCF8523_LowPulse14x64Hz = 7  /**< 218.750 ms  14/64ths second */
 };
 
 /** PCF8523 Offset modes for making temperature/aging/accuracy adjustments */
 enum Pcf8523OffsetMode {
-  PCF8523_TwoHours = 0x00, // Offset made every two hours
-  PCF8523_OneMinute = 0x80 // Offset made every minute
+  PCF8523_TwoHours = 0x00, /**< Offset made every two hours */
+  PCF8523_OneMinute = 0x80 /**< Offset made every minute */
 };
 
 /**************************************************************************/
@@ -335,9 +362,15 @@ public:
   boolean lostPower(void);
   boolean initialized(void);
   static DateTime now();
-
   Pcf8523SqwPinMode readSqwPinMode();
   void writeSqwPinMode(Pcf8523SqwPinMode mode);
+  void enableSecondTimer(void);
+  void disableSecondTimer(void);
+  void enableCountdownTimer(PCF8523TimerClockFreq clkFreq, uint8_t numPeriods,
+                            uint8_t lowPulseWidth);
+  void enableCountdownTimer(PCF8523TimerClockFreq clkFreq, uint8_t numPeriods);
+  void disableCountdownTimer(void);
+  void deconfigureAllTimers(void);
   void calibrate(Pcf8523OffsetMode mode, int8_t offset);
 };
 

--- a/examples/pcf8523Countdown/pcf8523Countdown.ino
+++ b/examples/pcf8523Countdown/pcf8523Countdown.ino
@@ -51,17 +51,17 @@ void setup () {
   // countdown period, then it will be released to be pulled HIGH again.
   pinMode(timerInterruptPin, INPUT_PULLUP);
 
-  Serial.println("\nStarting PCF8523 Countdown Timer example.");
-  Serial.print("Configured to expect PCF8523 INT/SQW pin connected to input pin: ");
+  Serial.println(F("\nStarting PCF8523 Countdown Timer example."));
+  Serial.print(F("Configured to expect PCF8523 INT/SQW pin connected to input pin: "));
   Serial.println(timerInterruptPin);
-  Serial.println("This example will not work without the interrupt pin connected!\n\n");
+  Serial.println(F("This example will not work without the interrupt pin connected!\n\n"));
 
   // Timer configuration is not cleared on an RTC reset due to battery backup!
   rtc.deconfigureAllTimers();
 
-  Serial.println("First, use the PCF8523's 'Countdown Timer' with an interrupt.");
-  Serial.println("Set the countdown for 10 seconds and we'll let it run for 2 rounds.");
-  Serial.println("Starting Countdown Timer now...");
+  Serial.println(F("First, use the PCF8523's 'Countdown Timer' with an interrupt."));
+  Serial.println(F("Set the countdown for 10 seconds and we'll let it run for 2 rounds."));
+  Serial.println(F("Starting Countdown Timer now..."));
 
   // These are the PCF8523's built-in "Timer Source Clock Frequencies".
   // They are predefined time periods you choose as your base unit of time,
@@ -101,12 +101,12 @@ void setup () {
   attachInterrupt(digitalPinToInterrupt(timerInterruptPin), countdownOver, FALLING);
 
   // This message proves we're not blocked while counting down!
-  Serial.println("  While we're waiting, a word of caution:");
-  Serial.println("  When starting a new countdown timer, the first time period is not of fixed");
-  Serial.println("  duration. The amount of inaccuracy for the first time period is up to one full");
-  Serial.println("  clock frequency. Example: just the first second of the first round of a new");
-  Serial.println("  countdown based on PCF8523_FrequencySecond may be off by as much as 1 second!");
-  Serial.println("  For critical timing, consider starting actions on the first interrupt.");
+  Serial.println(F("  While we're waiting, a word of caution:"));
+  Serial.println(F("  When starting a new countdown timer, the first time period is not of fixed"));
+  Serial.println(F("  duration. The amount of inaccuracy for the first time period is up to one full"));
+  Serial.println(F("  clock frequency. Example: just the first second of the first round of a new"));
+  Serial.println(F("  countdown based on PCF8523_FrequencySecond may be off by as much as 1 second!"));
+  Serial.println(F("  For critical timing, consider starting actions on the first interrupt."));
 }
 
 // Triggered by the PCF8523 Countdown Timer interrupt at the end of a countdown
@@ -125,33 +125,33 @@ void toggleLed () {
 
 void loop () {
   if (countdownInterruptTriggered && numCountdownInterrupts == 1) {
-    Serial.println("1st countdown interrupt triggered. Accurate timekeeping starts now.");
+    Serial.println(F("1st countdown interrupt triggered. Accurate timekeeping starts now."));
     countdownInterruptTriggered = false; // don't come in here again
   } else if (countdownInterruptTriggered && numCountdownInterrupts == 2) {
-    Serial.println("2nd countdown interrupt triggered. Disabling countdown and detaching interrupt.\n\n");
+    Serial.println(F("2nd countdown interrupt triggered. Disabling countdown and detaching interrupt.\n\n"));
     rtc.disableCountdownTimer();
     detachInterrupt(digitalPinToInterrupt(timerInterruptPin));
     delay(2000);
 
 
-    Serial.println("Now, set up the PCF8523's 'Second Timer' to toggle the built-in LED at 1Hz...");
+    Serial.println(F("Now, set up the PCF8523's 'Second Timer' to toggle the built-in LED at 1Hz..."));
     attachInterrupt(digitalPinToInterrupt(timerInterruptPin), toggleLed, FALLING);
     rtc.enableSecondTimer();
-    Serial.println("Look for the built-in LED to flash 1 second ON, 1 second OFF, repeat. ");
-    Serial.println("Meanwhile this program will use delay() to block code execution briefly");
-    Serial.println("before moving on to the last example. Notice the LED keeps blinking!\n\n");
+    Serial.println(F("Look for the built-in LED to flash 1 second ON, 1 second OFF, repeat. "));
+    Serial.println(F("Meanwhile this program will use delay() to block code execution briefly"));
+    Serial.println(F("before moving on to the last example. Notice the LED keeps blinking!\n\n"));
     delay(20000); // less accurate, blocks execution here. Meanwhile Second Timer keeps running.
     rtc.disableSecondTimer();
     detachInterrupt(digitalPinToInterrupt(timerInterruptPin));
 
 
-    Serial.println("Lastly, set up a Countdown Timer that works without attaching an interrupt...");
+    Serial.println(F("Lastly, set up a Countdown Timer that works without attaching an interrupt..."));
     rtc.enableCountdownTimer(PCF8523_Frequency64Hz, 32, PCF8523_LowPulse8x64Hz);
-    Serial.println("Look for the LED to turn on every 1/2 second and stay lit for 1/8th of a second.");
-    Serial.println("The countdown was set to a source clock frequency of 64 Hz (1/64th of a second)");
-    Serial.println("for a length of 32 time periods. 32 * 1/64th of a second is 1/2 of a second.");
-    Serial.println("The low pulse duration was set to 125 ms, or 1/8th of a second.");
-    Serial.println("The loop() keeps the built-in LED set to the opposite state of the INT/SQW pin.");
+    Serial.println(F("Look for the LED to turn on every 1/2 second and stay lit for 1/8th of a second."));
+    Serial.println(F("The countdown was set to a source clock frequency of 64 Hz (1/64th of a second)"));
+    Serial.println(F("for a length of 32 time periods. 32 * 1/64th of a second is 1/2 of a second."));
+    Serial.println(F("The low pulse duration was set to 125 ms, or 1/8th of a second."));
+    Serial.println(F("The loop() keeps the built-in LED set to the opposite state of the INT/SQW pin."));
 
 
     countdownInterruptTriggered = false; // don't come in here again

--- a/examples/pcf8523Countdown/pcf8523Countdown.ino
+++ b/examples/pcf8523Countdown/pcf8523Countdown.ino
@@ -1,0 +1,163 @@
+/**************************************************************************/
+/*
+  Countdown Timer using a PCF8523 RTC connected via I2C and Wire lib
+  with the INT/SQW pin wired to an interrupt-capable input.
+
+  According to the data sheet, the PCF8523 can run countdown timers
+  from 244 microseconds to 10.625 days:
+  https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf#page=34
+
+  This sketch sets a countdown timer, and executes code when it reaches 0,
+  then blinks the built-in LED like BlinkWithoutDelay, but without millis()!
+
+  NOTE:
+  You must connect the PCF8523's interrupt pin to your Arduino or other
+  microcontroller on an input pin that can handle interrupts, and that has a
+  pullup resistor. The pin will be briefly pulled low each time the countdown
+  reaches 0. This example will not work without the interrupt pin connected!
+
+  On Adafruit breakout boards, the interrupt pin is labeled 'INT' or 'SQW'.
+*/
+/**************************************************************************/
+
+#include "RTClib.h"
+
+RTC_PCF8523 rtc;
+
+// Input pin with interrupt capability
+// const int timerInterruptPin = 2;  // Most Arduinos
+const int timerInterruptPin = 5;  // Adafruit Feather M0/M4/nRF52840
+
+// Variables modified during an interrupt must be declared volatile
+volatile bool countdownInterruptTriggered = false;
+volatile int numCountdownInterrupts = 0;
+
+void setup () {
+  Serial.begin(57600);
+
+#ifndef ESP8266
+  while (!Serial); // wait for serial port to connect. Needed for native USB
+#endif
+
+  if (! rtc.begin()) {
+    Serial.println("Couldn't find RTC");
+    while (1);
+  }
+
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // Set the pin attached to PCF8523 INT to be an input with pullup to HIGH.
+  // The PCF8523 interrupt pin will briefly pull it LOW at the end of a given
+  // countdown period, then it will be released to be pulled HIGH again.
+  pinMode(timerInterruptPin, INPUT_PULLUP);
+
+  Serial.println("\nStarting PCF8523 Countdown Timer example.");
+  Serial.print("Configured to expect PCF8523 INT/SQW pin connected to input pin: ");
+  Serial.println(timerInterruptPin);
+  Serial.println("This example will not work without the interrupt pin connected!\n\n");
+
+  // Timer configuration is not cleared on an RTC reset due to battery backup!
+  rtc.deconfigureAllTimers();
+
+  Serial.println("First, use the PCF8523's 'Countdown Timer' with an interrupt.");
+  Serial.println("Set the countdown for 10 seconds and we'll let it run for 2 rounds.");
+  Serial.println("Starting Countdown Timer now...");
+
+  // These are the PCF8523's built-in "Timer Source Clock Frequencies".
+  // They are predefined time periods you choose as your base unit of time,
+  // depending on the length of countdown timer you need.
+  // The minimum length of your countdown is 1 time period.
+  // The maximum length of your countdown is 255 time periods.
+  //
+  // PCF8523_FrequencyHour   = 1 hour, max 10.625 days (255 hours)
+  // PCF8523_FrequencyMinute = 1 minute, max 4.25 hours
+  // PCF8523_FrequencySecond = 1 second, max 4.25 minutes
+  // PCF8523_Frequency64Hz   = 1/64 of a second (15.625 milliseconds), max 3.984 seconds
+  // PCF8523_Frequency4kHz   = 1/4096 of a second (244 microseconds), max 62.256 milliseconds
+  //
+  //
+  // These are the PCF8523's optional 'Low Pulse Widths' of time the interrupt
+  // pin is held LOW at the end of every countdown (frequency 64Hz or longer).
+  //
+  // PCF8523_LowPulse3x64Hz  =  46.875 ms   3/64ths second (default)
+  // PCF8523_LowPulse4x64Hz  =  62.500 ms   4/64ths second
+  // PCF8523_LowPulse5x64Hz  =  78.125 ms   5/64ths second
+  // PCF8523_LowPulse6x64Hz  =  93.750 ms   6/64ths second
+  // PCF8523_LowPulse8x64Hz  = 125.000 ms   8/64ths second
+  // PCF8523_LowPulse10x64Hz = 156.250 ms  10/64ths second
+  // PCF8523_LowPulse12x64Hz = 187.500 ms  12/64ths second
+  // PCF8523_LowPulse14x64Hz = 218.750 ms  14/64ths second
+  //
+  //
+  // Uncomment an example below:
+
+  // rtc.enableCountdownTimer(PCF8523_FrequencyHour, 24);    // 1 day
+  // rtc.enableCountdownTimer(PCF8523_FrequencyMinute, 150); // 2.5 hours
+  rtc.enableCountdownTimer(PCF8523_FrequencySecond, 10);  // 10 seconds
+  // rtc.enableCountdownTimer(PCF8523_Frequency64Hz, 32);    // 1/2 second
+  // rtc.enableCountdownTimer(PCF8523_Frequency64Hz, 16);    // 1/4 second
+  // rtc.enableCountdownTimer(PCF8523_Frequency4kHz, 205);   // 50 milliseconds
+
+  attachInterrupt(digitalPinToInterrupt(timerInterruptPin), countdownOver, FALLING);
+
+  // This message proves we're not blocked while counting down!
+  Serial.println("  While we're waiting, a word of caution:");
+  Serial.println("  When starting a new countdown timer, the first time period is not of fixed");
+  Serial.println("  duration. The amount of inaccuracy for the first time period is up to one full");
+  Serial.println("  clock frequency. Example: just the first second of the first round of a new");
+  Serial.println("  countdown based on PCF8523_FrequencySecond may be off by as much as 1 second!");
+  Serial.println("  For critical timing, consider starting actions on the first interrupt.");
+}
+
+// Triggered by the PCF8523 Countdown Timer interrupt at the end of a countdown
+// period. Meanwhile, the PCF8523 immediately starts the countdown again.
+void countdownOver () {
+  // Set a flag to run code in the loop():
+  countdownInterruptTriggered = true;
+  numCountdownInterrupts++;
+}
+
+// Triggered by the PCF8523 Second Timer every second.
+void toggleLed () {
+  // Run certain types of fast executing code here:
+  digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+}
+
+void loop () {
+  if (countdownInterruptTriggered && numCountdownInterrupts == 1) {
+    Serial.println("1st countdown interrupt triggered. Accurate timekeeping starts now.");
+    countdownInterruptTriggered = false; // don't come in here again
+  } else if (countdownInterruptTriggered && numCountdownInterrupts == 2) {
+    Serial.println("2nd countdown interrupt triggered. Disabling countdown and detaching interrupt.\n\n");
+    rtc.disableCountdownTimer();
+    detachInterrupt(digitalPinToInterrupt(timerInterruptPin));
+    delay(2000);
+
+
+    Serial.println("Now, set up the PCF8523's 'Second Timer' to toggle the built-in LED at 1Hz...");
+    attachInterrupt(digitalPinToInterrupt(timerInterruptPin), toggleLed, FALLING);
+    rtc.enableSecondTimer();
+    Serial.println("Look for the built-in LED to flash 1 second ON, 1 second OFF, repeat. ");
+    Serial.println("Meanwhile this program will use delay() to block code execution briefly");
+    Serial.println("before moving on to the last example. Notice the LED keeps blinking!\n\n");
+    delay(20000); // less accurate, blocks execution here. Meanwhile Second Timer keeps running.
+    rtc.disableSecondTimer();
+    detachInterrupt(digitalPinToInterrupt(timerInterruptPin));
+
+
+    Serial.println("Lastly, set up a Countdown Timer that works without attaching an interrupt...");
+    rtc.enableCountdownTimer(PCF8523_Frequency64Hz, 32, PCF8523_LowPulse8x64Hz);
+    Serial.println("Look for the LED to turn on every 1/2 second and stay lit for 1/8th of a second.");
+    Serial.println("The countdown was set to a source clock frequency of 64 Hz (1/64th of a second)");
+    Serial.println("for a length of 32 time periods. 32 * 1/64th of a second is 1/2 of a second.");
+    Serial.println("The low pulse duration was set to 125 ms, or 1/8th of a second.");
+    Serial.println("The loop() keeps the built-in LED set to the opposite state of the INT/SQW pin.");
+
+
+    countdownInterruptTriggered = false; // don't come in here again
+  }
+
+  // While countdown running, INT/SQW pullup to HIGH, set LED to LOW (off)
+  // When countdown is over, INT/SQW pulled down LOW, set LED to HIGH (on)
+  digitalWrite(LED_BUILTIN, !digitalRead(timerInterruptPin));
+}


### PR DESCRIPTION
With this change, the user may easily take advantage of additional timing capabilities of the PCF8523:

1) Enable a recurring 'Countdown Timer' with a range from microseconds to over 10 days.
The countdown timer has an interrupt enabled on the INT1 pin that is exposed as INT or SQW on Adafruit breakout boards.
At the end of every countdown, the INT pin is pulled low for an (optionally) adjustable period of time.
This allows a user to attach an interrupt that executes a piece of code at regular intervals, for sensor data collection or other uses.

2) Enable a 'Second Timer' (1Hz), requiring no parameters or configuration, for a fixed interval of 1 second.
This timer acts very much like a 1-second Countdown Timer, or the existing square wave timer with 'writeSqwPinMode(PCF8523_SquareWave1HZ)'.

The implementation of the Countdown Timer uses the PCF8523's 'Timer B' and there are couple reason for this choice:
- Timer B offers the advantage of programmable low pulse widths.
- Timer B can only function as a Countdown Timer, meaning enablement does not block any alternative uses.

Though not implemented at this time, the PCF8523's 'Timer A' may be used as a Watchdog Timer or Countdown Timer, with fixed width low pulses.
Given most MCUs have built in watchdog timer capability, and considering that Timer A and Timer B share the same INT pin exposed on Adafruit breakout boards, the additional value of Timer A appears to be limited. Still, steps were taken to allow future implementation of Timer A.

Enabling the Countdown or Second Timer causes any existing CLKOUT square wave, configured with writeSqwPinMode(), to halt.
Disabling the Countdown or Second Timer narrowly turns off just the chosen timer, preserving state flags for later reading, and preserving other configuration on the same registers.

A big-hammer function is provided to deconfigure all timers which comes in handy during development due to the battery backup on RTCs that prevents regular resets.

The included Arduino example exercises all functionality with and without interrupts, and attempts to educate a user on techniques and subtleties along the way.

Library source additions documented, tested, reviewed using Adafruit Doxyfile. Minor adjustments to existing documentation made for consistency across PCF8523 functions. Library source also formatted with clang-format.

Tested on PCF8523-equipped Adalogger FeatherWing with:
Arduino Mega 2560
Feather M4 Express
Feather nRF52840 Sense

The PCF8523 is available at low cost on a standalone breakout board, or on the Adalogger FeatherWing, so it seems worthy of additional library support. I needed timers for it personally and I have seen forum requests for timers as well. A previous effort to add this functionality seems to have stalled. If this PR is accepted, and there is interest in Timer A and Alarms, I can add those as well.