### PR TITLE
Verify RTC communication in PCF8523 and DS1307 begin()

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -755,13 +755,16 @@ static uint8_t bin2bcd(uint8_t val) { return val + 6 * (val / 10); }
 
 /**************************************************************************/
 /*!
-    @brief  Startup for the DS1307
-    @return Always true
+    @brief  Start I2C for the DS1307 and test succesful connection
+    @return True if Wire can find DS1307 or false otherwise.
 */
 /**************************************************************************/
 boolean RTC_DS1307::begin(void) {
   Wire.begin();
-  return true;
+  Wire.beginTransmission(DS1307_ADDRESS);
+  if (Wire.endTransmission() == 0)
+    return true;
+  return false;
 }
 
 /**************************************************************************/
@@ -995,13 +998,16 @@ DateTime RTC_Micros::now() {
 
 /**************************************************************************/
 /*!
-    @brief  Start using the PCF8523
-    @return True
+    @brief  Start I2C for the PCF8523 and test succesful connection
+    @return True if Wire can find PCF8523 or false otherwise.
 */
 /**************************************************************************/
 boolean RTC_PCF8523::begin(void) {
   Wire.begin();
-  return true;
+  Wire.beginTransmission(PCF8523_ADDRESS);
+  if (Wire.endTransmission() == 0)
+    return true;
+  return false;
 }
 
 /**************************************************************************/

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -14,6 +14,7 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
+    Serial.flush(); // ensure above text prints with nRF52 native USB Serial
     while (1);
   }
 

--- a/examples/pcf8523Countdown/pcf8523Countdown.ino
+++ b/examples/pcf8523Countdown/pcf8523Countdown.ino
@@ -41,6 +41,7 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
+    Serial.flush(); // ensure above text prints with nRF52 native USB Serial
     while (1);
   }
 


### PR DESCRIPTION
This change extends the logic already used for verifying comms with the DS3231 (ff898af) to the other two RTCs supported by this library: the PCF8523 and DS1307.

Fixes #64

I tested these controllers:
Feather M4 Express
Feather nRF52840 Sense
Arduino Mega

with these RTCs:
DS1307  DIY breakout board kit modified for pullup to 5v or 3v.
PCF8523 on RTC + SD Adalogger FeatherWing


Test Note: When `rtc.begin()` returns false, most examples print "Couldn't find RTC", and immediately go into an infinite `while(1)` loop. On the nRF52840 Sense, using native USB serial, the message never appears. Using a FTDI Friend on Serial1 *does print* the message as expected.

It's as if the message is buffered and there is no time to get it out through USB before entering the loop, and no ability to interrupt the loop to send it once inside.

These two workarounds cause the message to be printed as expected:
1) Call `Serial.flush()` prior to entering the while (1) loop
2) Add a brief delay inside the loop: `while (1) delay (1);`

I modified the PCF8523 examples to use flush(), but I left other examples with rtc.begin() alone for now. The newer, 3v nRF52 and the older, 5v DS1307 seem an unlikely combination, and I don't have a DS3231 to test. My plan is to bring this up with the adafruit/Adafruit_nRF52_Arduino maintainers, and see if there is an upstream fix or better workaround. I welcome any input the RTClib contributors have!