### PR TITLE
Ensure serial message printed and proper termination when RTC not found.

### DIFF
--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -14,7 +14,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   if (! rtc.isrunning()) {

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -44,7 +44,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   print_mode();

--- a/examples/ds1307nvram/ds1307nvram.ino
+++ b/examples/ds1307nvram/ds1307nvram.ino
@@ -20,7 +20,11 @@ void setup () {
   while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
 
-  rtc.begin();
+  if (! rtc.begin()) {
+    Serial.println("Couldn't find RTC");
+    Serial.flush();
+    abort();
+  }
 
   // Print old RAM contents on startup.
   Serial.println("Current NVRAM values:");

--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -14,7 +14,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   if (rtc.lostPower()) {

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -14,8 +14,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    Serial.flush(); // ensure above text prints with nRF52 native USB Serial
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   if (! rtc.initialized() || rtc.lostPower()) {

--- a/examples/pcf8523Countdown/pcf8523Countdown.ino
+++ b/examples/pcf8523Countdown/pcf8523Countdown.ino
@@ -41,8 +41,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    Serial.flush(); // ensure above text prints with nRF52 native USB Serial
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -21,7 +21,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   if (! rtc.isrunning()) {

--- a/examples/toString/toString.ino
+++ b/examples/toString/toString.ino
@@ -13,7 +13,8 @@ void setup () {
 
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
-    while (1);
+    Serial.flush();
+    abort();
   }
 
   if (! rtc.isrunning()) {


### PR DESCRIPTION
3f379ab (PR #166) added connection verification for the PCF8523 and DS1307 matching that of the DS3231. For each RTC, if begin() returns false, the intended behavior is to print a message, "Couldn't find RTC" to an attached serial terminal and then terminate.

This change is a follow-on that corrects two issues which were not seen as long as begin() always returned true, across all RTClib examples:
1) The method of termination in place was an endless loop: `while(1)`
However, as pointed out in PR #168, the behavior of such a loop is undefined. (See PR for interesting reading!) The `abort()` command effectively starts an endless loop, but without any side effects. It also makes clear to new users what the program is doing. H/T to contributor @edgar-bonet for this advice.

2) The message text "Couldn't find RTC" was not guaranteed to actually print on screen before the processor entered the endless loop.
This has to do with the way serial data is actually buffered and transfered down the line. On some boards, serial data is processed using interrupts. On others, such as the Feather nRF52840 which uses the TinyUSB stack, interrupts are not used at all, and serial processing waits for the CPU to become available. Whatever the case, `Serial.flush()` allows serial processing to finish before terminating with the endless loop.

An alternate way of handling 1 and 2, recommended by the TinyUSB author, is to enter the endless loop immediately, but call `yield()` inside to instruct the processor to go ahead and handle any latent requests that come in. This also makes the loop have defined behavior. E.g.:

```
  if (! rtc.begin()) {
    Serial.println("Couldn't find RTC");
    while (1) {
      yield();  // delay(1) would also suffice
    }
  }
```

A fuller discussion of termination methods can be viewed in PR #166.