### PR TITLE
Add functions for DS3231 32kHz Output

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1525,9 +1525,9 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 /**************************************************************************/
 void RTC_DS3231::enable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
-  status |= (0x1 << 3);
+  status |= (0x1 << 0x03);
   write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
-  //Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
+  // Serial.println(read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
 }
 
 /**************************************************************************/
@@ -1537,9 +1537,9 @@ void RTC_DS3231::enable32K(void) {
 /**************************************************************************/
 void RTC_DS3231::disable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
-  status &= ~(0x1 << 3);
+  status &= ~(0x1 << 0x03);
   write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
-  //Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
+  // Serial.println(read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
 }
 
 /**************************************************************************/
@@ -1550,5 +1550,5 @@ void RTC_DS3231::disable32K(void) {
 /**************************************************************************/
 bool RTC_DS3231::status32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
-  return (status >> (uint8_t) 0x03) & 0x1;
+  return (status >> 0x03) & 0x1;
 }

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1521,7 +1521,7 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 /**************************************************************************/
 /*!
     @brief  Enable 32KHz Output
-        @details Enables the open-drain 32kHz output on pin 1
+*/
 /**************************************************************************/
 void RTC_DS3231::enable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
@@ -1533,7 +1533,7 @@ void RTC_DS3231::enable32K(void) {
 /**************************************************************************/
 /*!
     @brief  Disable 32KHz Output
-        @details Disables the open-drain 32kHz output on pin 1
+*/
 /**************************************************************************/
 void RTC_DS3231::disable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
@@ -1545,7 +1545,7 @@ void RTC_DS3231::disable32K(void) {
 /**************************************************************************/
 /*!
     @brief  Get status of 32KHz Output
-        @return True if enabled otherwise false
+    @return True if enabled otherwise false
 */
 /**************************************************************************/
 bool RTC_DS3231::status32K(void) {

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1517,3 +1517,38 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
   return (status >> (alarm_num - 1)) & 0x1;
 }
+
+/**************************************************************************/
+/*!
+    @brief  Enable 32KHz Output
+        @param 	None
+/**************************************************************************/
+void RTC_DS3231::enable32K(void) {
+  uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
+  status |= (0x1 << 3);
+  write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
+  //Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Disable 32KHz Output
+        @param 	None
+/**************************************************************************/
+void RTC_DS3231::disable32K(void) {
+  uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
+  status &= ~(0x1 << 3);
+  write_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG, status);
+  //Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG), BIN);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Get status of 32KHz Output
+        @return True if enabled otherwise false
+*/
+/**************************************************************************/
+bool RTC_DS3231::status32K(void) {
+  uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
+  return (status >> (uint8_t) 0x03) & 0x1;
+}

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1521,7 +1521,7 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 /**************************************************************************/
 /*!
     @brief  Enable 32KHz Output
-        @param 	None
+        @details Enables the open-drain 32kHz output on pin 1
 /**************************************************************************/
 void RTC_DS3231::enable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
@@ -1533,7 +1533,7 @@ void RTC_DS3231::enable32K(void) {
 /**************************************************************************/
 /*!
     @brief  Disable 32KHz Output
-        @param 	None
+        @details Disables the open-drain 32kHz output on pin 1
 /**************************************************************************/
 void RTC_DS3231::disable32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1521,6 +1521,8 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 /**************************************************************************/
 /*!
     @brief  Enable 32KHz Output
+    @details The 32kHz output is enabled by default. It requires an external
+    pull-up resistor to function correctly
 */
 /**************************************************************************/
 void RTC_DS3231::enable32K(void) {
@@ -1548,7 +1550,7 @@ void RTC_DS3231::disable32K(void) {
     @return True if enabled otherwise false
 */
 /**************************************************************************/
-bool RTC_DS3231::status32K(void) {
+bool RTC_DS3231::isEnabled32K(void) {
   uint8_t status = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
   return (status >> 0x03) & 0x1;
 }

--- a/RTClib.h
+++ b/RTClib.h
@@ -308,7 +308,7 @@ public:
   bool alarmFired(uint8_t alarm_num);
   void enable32K(void);
   void disable32K(void);
-  bool status32K(void);
+  bool isEnabled32K(void);
   static float getTemperature(); // in Celcius degree
 };
 

--- a/RTClib.h
+++ b/RTClib.h
@@ -306,6 +306,9 @@ public:
   void disableAlarm(uint8_t alarm_num);
   void clearAlarm(uint8_t alarm_num);
   bool alarmFired(uint8_t alarm_num);
+  void enable32K(void);
+  void disable32K(void);
+  bool status32K(void);
   static float getTemperature(); // in Celcius degree
 };
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -68,6 +68,9 @@ enableCountdownTimer	KEYWORD2
 disableCountdownTimer	KEYWORD2
 deconfigureAllTimers	KEYWORD2
 calibrate	KEYWORD2
+enable32K   KEYWORD2
+disable32K    KEYWORD2
+isEnabled32K    KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
This Pull Request adds functionality for the DS3231 to enable, disable and check the status of the optional 32kHz clock output which is available on some DS3231 modules. 

The new functions are included right at the bottom of RTClib.cpp and are based on the existing functions to enable and disable the internal Alarms

