### PR TITLE
Added DateTime(char *iso8601date) constructor.

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -369,6 +369,36 @@ DateTime::DateTime(const __FlashStringHelper *date,
 
 /**************************************************************************/
 /*!
+    @brief  Constructor for creating a DateTime from an ISO8601 date string
+
+    This constructor expects its parameters to be a string in the 
+    https://en.wikipedia.org/wiki/ISO_8601 format, e.g:
+
+    "2020-06-25T15:29:37"
+
+	The year must be > 2000, as only the offset is considered.
+
+    Usage:
+
+    ```
+    DateTime dt("2020-06-25T15:29:37");
+    ```
+
+*/
+/**************************************************************************/
+DateTime::DateTime(const char *iso8601date) {
+  yOff = conv2d(iso8601date + 2);
+  m    = conv2d(iso8601date + 5);
+  d    = conv2d(iso8601date + 8);
+  hh   = conv2d(iso8601date + 11);
+  mm   = conv2d(iso8601date + 14);
+  ss   = conv2d(iso8601date + 17);
+}
+
+
+
+/**************************************************************************/
+/*!
     @brief  Check whether this DateTime is valid.
     @return true if valid, false if not.
 */

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -376,13 +376,16 @@ DateTime::DateTime(const __FlashStringHelper *date,
 
     "2020-06-25T15:29:37"
 
-        The year must be > 2000, as only the offset is considered.
-
     Usage:
 
     ```
     DateTime dt("2020-06-25T15:29:37");
     ```
+
+    @note The year must be > 2000, as only the yOff is considered.
+
+    @param iso8601date a datetime string in iso8601 format,
+                e.g. "2020-06-25T15:29:37".
 
 */
 /**************************************************************************/

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -371,12 +371,12 @@ DateTime::DateTime(const __FlashStringHelper *date,
 /*!
     @brief  Constructor for creating a DateTime from an ISO8601 date string
 
-    This constructor expects its parameters to be a string in the 
+    This constructor expects its parameters to be a string in the
     https://en.wikipedia.org/wiki/ISO_8601 format, e.g:
 
     "2020-06-25T15:29:37"
 
-	The year must be > 2000, as only the offset is considered.
+        The year must be > 2000, as only the offset is considered.
 
     Usage:
 
@@ -388,14 +388,12 @@ DateTime::DateTime(const __FlashStringHelper *date,
 /**************************************************************************/
 DateTime::DateTime(const char *iso8601date) {
   yOff = conv2d(iso8601date + 2);
-  m    = conv2d(iso8601date + 5);
-  d    = conv2d(iso8601date + 8);
-  hh   = conv2d(iso8601date + 11);
-  mm   = conv2d(iso8601date + 14);
-  ss   = conv2d(iso8601date + 17);
+  m = conv2d(iso8601date + 5);
+  d = conv2d(iso8601date + 8);
+  hh = conv2d(iso8601date + 11);
+  mm = conv2d(iso8601date + 14);
+  ss = conv2d(iso8601date + 17);
 }
-
-
 
 /**************************************************************************/
 /*!

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -384,19 +384,21 @@ DateTime::DateTime(const __FlashStringHelper *date,
 
     @note The year must be > 2000, as only the yOff is considered.
 
-    @param iso8601date
-           A datetime string in iso8601 format,
+    @param iso8601dateTime
+           A dateTime string in iso8601 format,
            e.g. "2020-06-25T15:29:37".
 
 */
 /**************************************************************************/
-DateTime::DateTime(const char *iso8601date) {
-  yOff = conv2d(iso8601date + 2);
-  m = conv2d(iso8601date + 5);
-  d = conv2d(iso8601date + 8);
-  hh = conv2d(iso8601date + 11);
-  mm = conv2d(iso8601date + 14);
-  ss = conv2d(iso8601date + 17);
+DateTime::DateTime(const char *iso8601dateTime) {
+  char ref[] = "2000-01-01T00:00:00";
+  memcpy(ref, iso8601dateTime, strlen(ref));
+  yOff = conv2d(ref + 2);
+  m = conv2d(ref + 5);
+  d = conv2d(ref + 8);
+  hh = conv2d(ref + 11);
+  mm = conv2d(ref + 14);
+  ss = conv2d(ref + 17);
 }
 
 /**************************************************************************/

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -369,7 +369,7 @@ DateTime::DateTime(const __FlashStringHelper *date,
 
 /**************************************************************************/
 /*!
-    @brief  Constructor for creating a DateTime from an ISO8601 date string
+    @brief  Constructor for creating a DateTime from an ISO8601 date string.
 
     This constructor expects its parameters to be a string in the
     https://en.wikipedia.org/wiki/ISO_8601 format, e.g:
@@ -384,8 +384,9 @@ DateTime::DateTime(const __FlashStringHelper *date,
 
     @note The year must be > 2000, as only the yOff is considered.
 
-    @param iso8601date a datetime string in iso8601 format,
-                e.g. "2020-06-25T15:29:37".
+    @param iso8601date
+           A datetime string in iso8601 format,
+           e.g. "2020-06-25T15:29:37".
 
 */
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -79,6 +79,7 @@ public:
   DateTime(const DateTime &copy);
   DateTime(const char *date, const char *time);
   DateTime(const __FlashStringHelper *date, const __FlashStringHelper *time);
+  DateTime(const char *iso8601date);
   bool isValid() const;
   char *toString(char *buffer);
 


### PR DESCRIPTION
Please consider this small patch to your lib. 

It only creates an additional DateTime constructor which creates a DateTime object from a
ISO8601 formatted string. (e.g. 2020-06-25T15:29:37) 
See: https://en.wikipedia.org/wiki/ISO_8601

Limitations of this change are, that only years > 2000 will be correct, as only the yOffs is parsed,
as this library is missing a conv4d function. 

The code should not break anything as it is a complete new constructor, the only one 
which accepts a single const char *.

Best regards,

Michael
