### PR TITLE
Make iso8601 DateTime constructor more tolerant

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -392,7 +392,7 @@ DateTime::DateTime(const __FlashStringHelper *date,
 /**************************************************************************/
 DateTime::DateTime(const char *iso8601dateTime) {
   char ref[] = "2000-01-01T00:00:00";
-  memcpy(ref, iso8601dateTime, strlen(ref));
+  memcpy(ref, iso8601dateTime, min(strlen(ref), strlen(iso8601dateTime)));
   yOff = conv2d(ref + 2);
   m = conv2d(ref + 5);
   d = conv2d(ref + 8);


### PR DESCRIPTION
This is a small fix for PR #173. The new constructor

```cpp
DateTime::DateTime(const char *iso8601dateTime);
```

was meant to accept incomplete specifications like, e.g. date only. In such case, however, it would read past the end of the supplied string.

This pull request fixes the issue by copying into the template `ref` no more characters than what has been supplied. It has been tested on a simulated Uno using the following sketch:

```cpp
#include <RTClib.h>

RTC_Millis rtc;

void setup() {
    Serial.begin(9600);
    Serial.println(DateTime("2020-06-29T18:12").timestamp());
    Serial.println(DateTime("2020-06-29T18").timestamp());
    Serial.println(DateTime("2020-06-29").timestamp());
    Serial.println(DateTime("2020-06").timestamp());
}

/* Exit simavr. */
#include <avr/sleep.h>
void loop() {
    Serial.flush();
    cli();
    sleep_mode();
}
```
