### PR TITLE
Add start and stop functionality for pcf8523

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1129,10 +1129,9 @@ DateTime RTC_PCF8523::now() {
     @brief  Resets the STOP bit in register Control_1
 */
 /**************************************************************************/
-void RTC_PCF8523::start(void)
-{
+void RTC_PCF8523::start(void) {
   uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
-  if(ctlreg & (1<<5))
+  if (ctlreg & (1<<5))
   {
     write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg & ~(1 << 5));
   }
@@ -1143,10 +1142,9 @@ void RTC_PCF8523::start(void)
     @brief  Sets the STOP bit in register Control_1
 */
 /**************************************************************************/
-void RTC_PCF8523::stop(void)
-{
+void RTC_PCF8523::stop(void) {
   uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
-  if(!(ctlreg & (1<<5)))
+  if (!(ctlreg & (1<<5)))
   {
     write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg | (1 << 5));
   }
@@ -1158,8 +1156,7 @@ void RTC_PCF8523::stop(void)
     @return 1 if the RTC is running, 0 if not
 */
 /**************************************************************************/
-uint8_t RTC_PCF8523::isrunning()
-{
+uint8_t RTC_PCF8523::isrunning() {
   uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
   return !((ctlreg >> 5) & 1);
 }

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1131,8 +1131,7 @@ DateTime RTC_PCF8523::now() {
 /**************************************************************************/
 void RTC_PCF8523::start(void) {
   uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
-  if (ctlreg & (1<<5))
-  {
+  if (ctlreg & (1 << 5)) {
     write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg & ~(1 << 5));
   }
 }
@@ -1144,8 +1143,7 @@ void RTC_PCF8523::start(void) {
 /**************************************************************************/
 void RTC_PCF8523::stop(void) {
   uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
-  if (!(ctlreg & (1<<5)))
-  {
+  if (!(ctlreg & (1 << 5))) {
     write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg | (1 << 5));
   }
 }

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1126,6 +1126,46 @@ DateTime RTC_PCF8523::now() {
 
 /**************************************************************************/
 /*!
+    @brief  Resets the STOP bit in register Control_1
+*/
+/**************************************************************************/
+void RTC_PCF8523::start(void)
+{
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
+  if(ctlreg & (1<<5))
+  {
+    write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg & ~(1 << 5));
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets the STOP bit in register Control_1
+*/
+/**************************************************************************/
+void RTC_PCF8523::stop(void)
+{
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
+  if(!(ctlreg & (1<<5)))
+  {
+    write_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1, ctlreg | (1 << 5));
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Is the PCF8523 running? Check the STOP bit in register Control_1
+    @return 1 if the RTC is running, 0 if not
+*/
+/**************************************************************************/
+uint8_t RTC_PCF8523::isrunning()
+{
+  uint8_t ctlreg = read_i2c_register(PCF8523_ADDRESS, PCF8523_CONTROL_1);
+  return !((ctlreg >> 5) & 1);
+}
+
+/**************************************************************************/
+/*!
     @brief  Read the mode of the INT/SQW pin on the PCF8523
     @return SQW pin mode as a #Pcf8523SqwPinMode enum
 */

--- a/RTClib.h
+++ b/RTClib.h
@@ -366,6 +366,9 @@ public:
   boolean lostPower(void);
   boolean initialized(void);
   static DateTime now();
+  void start(void);
+  void stop(void);
+  uint8_t isrunning();
   Pcf8523SqwPinMode readSqwPinMode();
   void writeSqwPinMode(Pcf8523SqwPinMode mode);
   void enableSecondTimer(void);

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -39,6 +39,11 @@ void setup () {
   // This line sets the RTC with an explicit date & time, for example to set
   // January 21, 2014 at 3am you would call:
   // rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));
+
+  // When the RTC was stopped and stays connected to the battery, it has
+  // to be restarted by clearing the STOP bit. Let's do this to ensure
+  // the RTC is running.
+  rtc.start();
 }
 
 void loop () {


### PR DESCRIPTION
When a PCF8523 was stopped and stays connected to the battery, it has to be restarted by clearing the STOP bit. Currently the library has no possibility to start a stopped PCF8523.
This change adds functions for starting and stopping the PCF8523 and for checking, if it's running. The functions were added to the RTC_PCF8523 class (.h and .cpp). The isrunning function returns uint8_t instead of the better suited boolean for compatibility with the RTC_DS1307::isrunning function.
Existing code is not affected.