### PR TITLE
Remove use of String in timestamp function. Use char array instead.

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -689,9 +689,11 @@ bool DateTime::operator==(const DateTime &right) const {
     (`TIMESTAMP_FULL`).
 
     @see The `toString()` method provides more general string formatting.
-
+    
+    @param buffer A char array with 20 bytes. The number 20 is specified to
+    ensure the input buffer is never too small. The method will overwrite
+    the given buffer with the formatted date and/or time specified by opt.
     @param opt Format of the timestamp
-    @return Timestamp string, e.g. "2020-04-16T18:34:56".
 */
 /**************************************************************************/
 void DateTime::timestamp(char buffer[20], timestampOpt opt) {

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -690,9 +690,10 @@ bool DateTime::operator==(const DateTime &right) const {
 
     @see The `toString()` method provides more general string formatting.
     
-    @param buffer A char array with 20 bytes. The number 20 is specified to
-    ensure the input buffer is never too small. The method will overwrite
-    the given buffer with the formatted date and/or time specified by opt.
+    @param buffer A char array with 20 bytes. The number 20 is specified
+        to ensure the input buffer is never too small. The method will
+        overwrite the given buffer with the formatted date and/or time
+        specified by opt
     @param opt Format of the timestamp
 */
 /**************************************************************************/

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -681,7 +681,7 @@ bool DateTime::operator==(const DateTime &right) const {
 
 /**************************************************************************/
 /*!
-    @brief  Return a ISO 8601 timestamp as a `String` object.
+    @brief  Return a ISO 8601 timestamp as a char array.
 
     The generated timestamp conforms to one of the predefined, ISO
     8601-compatible formats for representing the date (if _opt_ is
@@ -694,9 +694,7 @@ bool DateTime::operator==(const DateTime &right) const {
     @return Timestamp string, e.g. "2020-04-16T18:34:56".
 */
 /**************************************************************************/
-String DateTime::timestamp(timestampOpt opt) {
-  char buffer[20];
-
+void DateTime::timestamp(char buffer[20], timestampOpt opt) {
   // Generate timestamp according to opt
   switch (opt) {
   case TIMESTAMP_TIME:
@@ -712,7 +710,6 @@ String DateTime::timestamp(timestampOpt opt) {
     sprintf(buffer, "%d-%02d-%02dT%02d:%02d:%02d", 2000 + yOff, m, d, hh, mm,
             ss);
   }
-  return String(buffer);
 }
 
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -138,7 +138,7 @@ public:
     TIMESTAMP_TIME, //!< `hh:mm:ss`
     TIMESTAMP_DATE  //!< `YYYY-MM-DD`
   };
-  String timestamp(timestampOpt opt = TIMESTAMP_FULL);
+  void timestamp(char buf[20], timestampOpt opt = TIMESTAMP_FULL);
 
   DateTime operator+(const TimeSpan &span);
   DateTime operator-(const TimeSpan &span);

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -46,14 +46,23 @@ void setup () {
 void loop() {
  DateTime time = rtc.now();
 
- //Full Timestamp
- Serial.println("DateTime::TIMESTAMP_FULL:\t" + time.timestamp(DateTime::TIMESTAMP_FULL));
+ // Create array to store timestamp.
+ char buffer[20];
 
- //Date Only
- Serial.println("DateTime::TIMESTAMP_DATE:\t" + time.timestamp(DateTime::TIMESTAMP_DATE));
+ // Full Timestamp
+ time.timestamp(buffer, DateTime::TIMESTAMP_FULL);
+ Serial.print("DateTime::TIMESTAMP_FULL:\t");
+ Serial.println(buffer);
 
- //Full Timestamp
- Serial.println("DateTime::TIMESTAMP_TIME:\t" + time.timestamp(DateTime::TIMESTAMP_TIME));
+ // Date Only
+ time.timestamp(buffer, DateTime::TIMESTAMP_DATE);
+ Serial.print("DateTime::TIMESTAMP_DATE:\t");
+ Serial.println(buffer);
+
+ // Full Timestamp
+ time.timestamp(buffer, DateTime::TIMESTAMP_TIME);
+ Serial.print("DateTime::TIMESTAMP_TIME:\t");
+ Serial.println(buffer);
 
  Serial.println("\n");
 

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -47,13 +47,13 @@ void loop() {
  DateTime time = rtc.now();
 
  //Full Timestamp
- Serial.println(String("DateTime::TIMESTAMP_FULL:\t")+time.timestamp(DateTime::TIMESTAMP_FULL));
+ Serial.println("DateTime::TIMESTAMP_FULL:\t" + time.timestamp(DateTime::TIMESTAMP_FULL));
 
  //Date Only
- Serial.println(String("DateTime::TIMESTAMP_DATE:\t")+time.timestamp(DateTime::TIMESTAMP_DATE));
+ Serial.println("DateTime::TIMESTAMP_DATE:\t" + time.timestamp(DateTime::TIMESTAMP_DATE));
 
  //Full Timestamp
- Serial.println(String("DateTime::TIMESTAMP_TIME:\t")+time.timestamp(DateTime::TIMESTAMP_TIME));
+ Serial.println("DateTime::TIMESTAMP_TIME:\t" + time.timestamp(DateTime::TIMESTAMP_TIME));
 
  Serial.println("\n");
 


### PR DESCRIPTION

Fixes issue #179 

The `String` class is only used in the library within the `timestamp()` function. It can be unreliable on the Arduino (AVR) platform. I think this change could also be about consistency, why not let the end user choose whether he uses String class or not? 

The code should behave just like the unmodified function. I only changed the data type from String to char *. As I understand it char * should have less limitations than String.

Only the example Timestamp needs to be modified. I can do that if this change is OK.


