### PR TITLE
Improved (in)equality efficiency

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -660,6 +660,9 @@ TimeSpan DateTime::operator-(const DateTime &right) {
 /*!
     @author Anton Rieutskyi
     @brief  Test if one DateTime is less (earlier) than another.
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
     @param right Comparison DateTime object
     @return True if the left DateTime is earlier than the right one,
         false otherwise.
@@ -684,6 +687,9 @@ bool DateTime::operator<(const DateTime &right) const {
 /*!
     @author Anton Rieutskyi
     @brief  Test if two DateTime objects are equal.
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
     @param right Comparison DateTime object
     @return True if both DateTime objects are the same, false otherwise.
 */

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -658,6 +658,7 @@ TimeSpan DateTime::operator-(const DateTime &right) {
 
 /**************************************************************************/
 /*!
+    @author Anton Rieutskyi
     @brief  Test if one DateTime is less (earlier) than another.
     @param right Comparison DateTime object
     @return True if the left DateTime is earlier than the right one,
@@ -665,18 +666,36 @@ TimeSpan DateTime::operator-(const DateTime &right) {
 */
 /**************************************************************************/
 bool DateTime::operator<(const DateTime &right) const {
-  return unixtime() < right.unixtime();
+   return (
+      yOff + 2000 < right.year() || (
+      yOff + 2000 == right.year() && (
+      m < right.month() || (
+      m == right.month() && (
+      d < right.day() || (
+      d == right.day() && (
+      hh < right.hour() || (
+      hh == right.hour() && (
+      mm < right.minute() || (
+      mm == right.minute() &&
+      ss < right.second() ) ) ) ) ) ) ) ) ) );
 }
 
 /**************************************************************************/
 /*!
+    @author Anton Rieutskyi
     @brief  Test if two DateTime objects are equal.
     @param right Comparison DateTime object
     @return True if both DateTime objects are the same, false otherwise.
 */
 /**************************************************************************/
 bool DateTime::operator==(const DateTime &right) const {
-  return unixtime() == right.unixtime();
+  return (
+    right.year()   == yOff + 2000 &&
+    right.month()  == m    &&
+    right.day()    == d    &&
+    right.hour()   == hh   &&
+    right.minute() == mm   &&
+    right.second() == ss);
 }
 
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -146,6 +146,9 @@ public:
   bool operator<(const DateTime &right) const;
   /*!
       @brief  Test if one DateTime is greater (later) than another.
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
       @param right DateTime object to compare
       @return True if the left DateTime is later than the right one,
         false otherwise
@@ -153,6 +156,9 @@ public:
   bool operator>(const DateTime &right) const { return right < *this; }
   /*!
       @brief  Test if one DateTime is less (earlier) than or equal to another
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
       @param right DateTime object to compare
       @return True if the left DateTime is earlier than or equal to the
         right one, false otherwise
@@ -160,6 +166,9 @@ public:
   bool operator<=(const DateTime &right) const { return !(*this > right); }
   /*!
       @brief  Test if one DateTime is greater (later) than or equal to another
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
       @param right DateTime object to compare
       @return True if the left DateTime is later than or equal to the right
         one, false otherwise
@@ -168,6 +177,9 @@ public:
   bool operator==(const DateTime &right) const;
   /*!
       @brief  Test if two DateTime objects are not equal.
+    @warning if one or both DateTime objects are invalid, logic errors can
+        occur
+    @see `isValid()` method
       @param right DateTime object to compare
       @return True if the two objects are not equal, false if they are
   */


### PR DESCRIPTION
Refactored `operator<()` and `operator==()` by using data members directly instead of using slow `unixtime()` method.