### PR TITLE
Wrote `fixDateTime()` method

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -120,6 +120,17 @@ const uint8_t daysInMonth[] PROGMEM = {31, 28, 31, 30, 31, 30,
 
 /**************************************************************************/
 /*!
+    @brief checks if the year is a leap year
+    @param year The year to checks
+    @return true if a leap year, false otherwise
+*/
+/**************************************************************************/
+bool isLeapYear(uint16_t year) {
+  return year % 400 == 0 || (year % 4 == 0 && year % 100 != 0);
+}
+
+/**************************************************************************/
+/*!
     @brief  Given a date, return number of days since 2000/01/01,
             valid for 2000--2099
     @param y Year
@@ -413,6 +424,43 @@ bool DateTime::isValid() const {
   DateTime other(unixtime());
   return yOff == other.yOff && m == other.m && d == other.d && hh == other.hh &&
          mm == other.mm && ss == other.ss;
+}
+
+/**************************************************************************/
+/*!
+    @author Harrison Outram
+    @brief  Fixes DateTime object if invalid
+
+    Determines if any date or time components are too high.
+    E.g. seconds == 65
+
+    Increments next component and reduces invalid component to fix.
+    E.g. if seconds == 125, then minutes goes up by 2 and seconds
+    goes down to 5.
+
+    @warning Will still result in invalid DateTime if year is above 2099
+    @return true if fixed, false if year becomes invalid
+*/
+/**************************************************************************/
+bool DateTime::fixDateTime() {
+  uint8_t temp;
+
+  if (ss >= 60) {
+    temp = ss / 60;
+    mm += temp;
+    ss -= 60 * temp;
+  }
+  if (mm >= 60) {
+    temp = mm / 60;
+    hh += temp;
+    mm -= 60 * temp;
+  }
+  if (hh >= 24) {
+    temp = hh / 24;
+    d += temp;
+    hh -= temp * 24;
+  }
+
 }
 
 /**************************************************************************/

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -465,7 +465,9 @@ bool DateTime::isValid() const {
     E.g. if seconds == 125, then minutes goes up by 2 and seconds
     goes down to 5.
 
-    @warning Will still result in invalid DateTime if year is above 2099
+    Does nothing if the DateTime object is already valid
+
+    @warning Will still result in invalid DateTime object if year is above 2099
     @return true if fixed, false if year becomes invalid
 */
 /**************************************************************************/

--- a/RTClib.h
+++ b/RTClib.h
@@ -55,14 +55,8 @@ class TimeSpan;
 #define SECONDS_FROM_1970_TO_2000                                              \
   946684800 ///< Unixtime for 2000-01-01 00:00:00, useful for initialization
 
-/**************************************************************************/
-/*!
-    @brief checks if the year is a leap year
-    @param year The year to checks
-    @return true if a leap year, false otherwise
-*/
-/**************************************************************************/
 bool isLeapYear(uint16_t year);
+uint8_t getDaysInMonth(uint16_t year, uint8_t month);
 
 /**************************************************************************/
 /*!

--- a/RTClib.h
+++ b/RTClib.h
@@ -57,6 +57,15 @@ class TimeSpan;
 
 /**************************************************************************/
 /*!
+    @brief checks if the year is a leap year
+    @param year The year to checks
+    @return true if a leap year, false otherwise
+*/
+/**************************************************************************/
+bool isLeapYear(uint16_t year);
+
+/**************************************************************************/
+/*!
     @brief  Simple general-purpose date/time class (no TZ / DST / leap
             seconds).
 
@@ -81,6 +90,7 @@ public:
   DateTime(const __FlashStringHelper *date, const __FlashStringHelper *time);
   DateTime(const char *iso8601date);
   bool isValid() const;
+  bool fixDateTime();
   char *toString(char *buffer);
 
   /*!


### PR DESCRIPTION
Wrote `fixDateTime()` method to allow for invalid DateTime objects to fix themselves. Method does nothing if DateTime object is already valid.

Also wrote `getDaysInMonth()` and `isLeapYear()` functions for utility purposes (used by `fixDateTime()`, hence the inclusions).