### PR TITLE
Avoid buffer overflow on invalid DateTime

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -695,7 +695,7 @@ bool DateTime::operator==(const DateTime &right) const {
 */
 /**************************************************************************/
 String DateTime::timestamp(timestampOpt opt) {
-  char buffer[20];
+  char buffer[25]; // large enough for any DateTime, including invalid ones
 
   // Generate timestamp according to opt
   switch (opt) {


### PR DESCRIPTION
The `timestamp()` method overflows its internal buffer if any of the data fields of the provided `DateTime` (save for `yOff`) is larger than&nbsp;99. Such `DateTime` objects are all invalid. This pull request makes the method safe for any `DateTime`, whether it is valid or not.

Although it is understood that nothing meaningful should be expected out of invalid data, corrupting memory should always be avoided. The rationale is that it is fine for operations on invalid data to yield _unspecified_ (i.e. meaningless) results, but _undefined behavior_ (i.e. anything can happen, including a crash) should always be avoided.

Incidentally, the patched `timestamp()` method happens to return a meaningful representation, even for invalid `DateTime` objects: it exposes the contents of the object members. This turned out to be useful for testing the proposed `fixDateTime()` method, from pull request #185.