### PR TITLE
Document the code formatting requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ https://learn.adafruit.com/the-well-automated-arduino-library/doxygen
 
 https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips
 
+## Code formatting and clang-format
+The code should be formatted according to the [LLVM Coding Standards][std], which is the default of the clang-format tool.  The easiest way to ensure conformance is to [install clang-format][llvm] and run
+
+```shell
+clang-format -i <source_file>`
+```
+
 Written by JeeLabs
 MIT license, check license.txt for more information
 All text above must be included in any redistribution


### PR DESCRIPTION
Most recent pull requests failed at some point the continuous integration checks because of `clang-format`. As the code formatting requirements are not documented, and the `clang-format` tool is very picky, the experience can be frustrating for new contributors.

This pull request documents these requirements in the README file, and gives the recipe for easily ensuring conformance.

I am not entirely convinced that the README is the right place for this.  The guidelines for new contributors are currently split between three files:

* The “Contributing” section of README.md:
  * welcomes contributions
  * references the code of conduct
  * states the documentation requirements (Doxygen)
  * may state the formatting requirements if this PR is accepted
* The code of conduct focuses on social behavior
* The pull request template:
  * explains what the “cover letter” of the pull request should describe
  * asks to run tests

Although I believe this pull request is a reasonable interim solution, a better long-term approach may be to consolidate all these guidelines into a single [`CONTRIBUTING.md` file][contrib]. This file may also have a word about submitting issues and about the pull request process. It may be shared across projects if it is generic enough. The README and the pull request template would then reference this file, maybe including a very short summary.

Any thoughts?

[contrib]: https://mozillascience.github.io/working-open-workshop/contributing/