### PR TITLE
fix DS3231_A1_Day and DS3231_A2_Day issue

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -571,12 +571,12 @@ uint8_t DateTime::twelveHour() const {
 /**************************************************************************/
 /*!
     @brief  Return the day of the week.
-    @return Day of week as an integer from 0 (Sunday) to 6 (Saturday).
+    @return Day of week as an integer from 1 (Sunday) to 7 (Saturday).
 */
 /**************************************************************************/
 uint8_t DateTime::dayOfTheWeek() const {
   uint16_t day = date2days(yOff, m, d);
-  return (day + 6) % 7; // Jan 1, 2000 is a Saturday, i.e. returns 6
+  return ((day + 6) % 7) + 1; // Jan 1, 2000 is a Saturday, i.e. returns 7
 }
 
 /**************************************************************************/
@@ -1394,7 +1394,7 @@ void RTC_DS3231::adjust(const DateTime &dt) {
   Wire._I2C_WRITE(bin2bcd(dt.second()));
   Wire._I2C_WRITE(bin2bcd(dt.minute()));
   Wire._I2C_WRITE(bin2bcd(dt.hour()));
-  Wire._I2C_WRITE(bin2bcd(0));
+  Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()));
   Wire._I2C_WRITE(bin2bcd(dt.day()));
   Wire._I2C_WRITE(bin2bcd(dt.month()));
   Wire._I2C_WRITE(bin2bcd(dt.year() - 2000));

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -571,12 +571,12 @@ uint8_t DateTime::twelveHour() const {
 /**************************************************************************/
 /*!
     @brief  Return the day of the week.
-    @return Day of week as an integer from 1 (Sunday) to 7 (Saturday).
+    @return Day of week as an integer from 0 (Sunday) to 6 (Saturday).
 */
 /**************************************************************************/
 uint8_t DateTime::dayOfTheWeek() const {
   uint16_t day = date2days(yOff, m, d);
-  return ((day + 6) % 7) + 1; // Jan 1, 2000 is a Saturday, i.e. returns 7
+  return (day + 6) % 7; // Jan 1, 2000 is a Saturday, i.e. returns 6
 }
 
 /**************************************************************************/
@@ -1358,6 +1358,16 @@ void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
 
 /**************************************************************************/
 /*!
+    @brief  Convert the day of the week to a representation suitable for
+            storing in the DS3231: from 1 (Monday) to 7 (Sunday).
+    @param  d Day of the week as represented by the library:
+            from 0 (Sunday) to 6 (Saturday).
+*/
+/**************************************************************************/
+static uint8_t dowToDS3231(uint8_t d) { return d == 0 ? 7 : d; }
+
+/**************************************************************************/
+/*!
     @brief  Start I2C for the DS3231 and test succesful connection
     @return True if Wire can find DS3231 or false otherwise.
 */
@@ -1394,7 +1404,7 @@ void RTC_DS3231::adjust(const DateTime &dt) {
   Wire._I2C_WRITE(bin2bcd(dt.second()));
   Wire._I2C_WRITE(bin2bcd(dt.minute()));
   Wire._I2C_WRITE(bin2bcd(dt.hour()));
-  Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()));
+  Wire._I2C_WRITE(bin2bcd(dowToDS3231(dt.dayOfTheWeek())));
   Wire._I2C_WRITE(bin2bcd(dt.day()));
   Wire._I2C_WRITE(bin2bcd(dt.month()));
   Wire._I2C_WRITE(bin2bcd(dt.year() - 2000));
@@ -1523,7 +1533,7 @@ bool RTC_DS3231::setAlarm1(const DateTime &dt, Ds3231Alarm1Mode alarm_mode) {
   Wire._I2C_WRITE(bin2bcd(dt.minute()) | A1M2);
   Wire._I2C_WRITE(bin2bcd(dt.hour()) | A1M3);
   if (DY_DT) {
-    Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()) | A1M4 | DY_DT);
+    Wire._I2C_WRITE(bin2bcd(dowToDS3231(dt.dayOfTheWeek())) | A1M4 | DY_DT);
   } else {
     Wire._I2C_WRITE(bin2bcd(dt.day()) | A1M4 | DY_DT);
   }
@@ -1559,7 +1569,7 @@ bool RTC_DS3231::setAlarm2(const DateTime &dt, Ds3231Alarm2Mode alarm_mode) {
   Wire._I2C_WRITE(bin2bcd(dt.minute()) | A2M2);
   Wire._I2C_WRITE(bin2bcd(dt.hour()) | A2M3);
   if (DY_DT) {
-    Wire._I2C_WRITE(bin2bcd(dt.dayOfTheWeek()) | A2M4 | DY_DT);
+    Wire._I2C_WRITE(bin2bcd(dowToDS3231(dt.dayOfTheWeek())) | A2M4 | DY_DT);
   } else {
     Wire._I2C_WRITE(bin2bcd(dt.day()) | A2M4 | DY_DT);
   }


### PR DESCRIPTION
Hi adafruit,

I modified `DateTime::dayOfTheWeek` and `RTC_DS3231::adjust` to reflect day-of-week register as specified on [DS3231](https://cdn-shop.adafruit.com/product-files/3013/DS3231.pdf) and [DS1307](https://datasheets.maximintegrated.com/en/ds/DS1307.pdf) ([see discussion here](https://github.com/adafruit/RTClib/issues/193)). Unit tested on uno 328p ([test file](https://github.com/adafruit/RTClib/files/5251653/main.zip)).
![image](https://user-images.githubusercontent.com/12877584/93711265-fce34480-fb8b-11ea-8041-11a829e971ac.png)

A possible limitation is that [PCF8523](https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf) works with 0 to 6 for day-of-week.

Cheers,

Robson



