### PR TITLE
Force unsigned integer aritmetic for all year 2000 calculations

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -129,8 +129,8 @@ const uint8_t daysInMonth[] PROGMEM = {31, 28, 31, 30, 31, 30,
 */
 /**************************************************************************/
 static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {
-  if (y >= 2000)
-    y -= 2000;
+  if (y >= 2000U)
+    y -= 2000U;
   uint16_t days = d;
   for (uint8_t i = 1; i < m; ++i)
     days += pgm_read_byte(daysInMonth + i - 1);
@@ -225,8 +225,8 @@ DateTime::DateTime(uint32_t t) {
 /**************************************************************************/
 DateTime::DateTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour,
                    uint8_t min, uint8_t sec) {
-  if (year >= 2000)
-    year -= 2000;
+  if (year >= 2000U)
+    year -= 2000U;
   yOff = year;
   m = month;
   d = day;
@@ -669,8 +669,8 @@ TimeSpan DateTime::operator-(const DateTime &right) {
 */
 /**************************************************************************/
 bool DateTime::operator<(const DateTime &right) const {
-  return (yOff + 2000 < right.year() ||
-          (yOff + 2000 == right.year() &&
+  return (yOff + 2000U < right.year() ||
+          (yOff + 2000U == right.year() &&
            (m < right.month() ||
             (m == right.month() &&
              (d < right.day() ||
@@ -693,7 +693,7 @@ bool DateTime::operator<(const DateTime &right) const {
 */
 /**************************************************************************/
 bool DateTime::operator==(const DateTime &right) const {
-  return (right.year() == yOff + 2000 && right.month() == m &&
+  return (right.year() == yOff + 2000U && right.month() == m &&
           right.day() == d && right.hour() == hh && right.minute() == mm &&
           right.second() == ss);
 }
@@ -724,11 +724,11 @@ String DateTime::timestamp(timestampOpt opt) {
     break;
   case TIMESTAMP_DATE:
     // Only date
-    sprintf(buffer, "%d-%02d-%02d", 2000 + yOff, m, d);
+    sprintf(buffer, "%u-%02d-%02d", 2000U + yOff, m, d);
     break;
   default:
     // Full
-    sprintf(buffer, "%d-%02d-%02dT%02d:%02d:%02d", 2000 + yOff, m, d, hh, mm,
+    sprintf(buffer, "%u-%02d-%02dT%02d:%02d:%02d", 2000U + yOff, m, d, hh, mm,
             ss);
   }
   return String(buffer);
@@ -851,7 +851,7 @@ void RTC_DS1307::adjust(const DateTime &dt) {
   Wire._I2C_WRITE(bin2bcd(0));
   Wire._I2C_WRITE(bin2bcd(dt.day()));
   Wire._I2C_WRITE(bin2bcd(dt.month()));
-  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000));
+  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000U));
   Wire.endTransmission();
 }
 
@@ -873,7 +873,7 @@ DateTime RTC_DS1307::now() {
   Wire._I2C_READ();
   uint8_t d = bcd2bin(Wire._I2C_READ());
   uint8_t m = bcd2bin(Wire._I2C_READ());
-  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000;
+  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000U;
 
   return DateTime(y, m, d, hh, mm, ss);
 }
@@ -1110,7 +1110,7 @@ void RTC_PCF8523::adjust(const DateTime &dt) {
   Wire._I2C_WRITE(bin2bcd(dt.day()));
   Wire._I2C_WRITE(bin2bcd(0)); // skip weekdays
   Wire._I2C_WRITE(bin2bcd(dt.month()));
-  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000));
+  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000U));
   Wire.endTransmission();
 
   // set to battery switchover mode
@@ -1138,7 +1138,7 @@ DateTime RTC_PCF8523::now() {
   uint8_t d = bcd2bin(Wire._I2C_READ());
   Wire._I2C_READ(); // skip 'weekdays'
   uint8_t m = bcd2bin(Wire._I2C_READ());
-  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000;
+  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000U;
 
   return DateTime(y, m, d, hh, mm, ss);
 }
@@ -1408,7 +1408,7 @@ void RTC_DS3231::adjust(const DateTime &dt) {
   Wire._I2C_WRITE(bin2bcd(dowToDS3231(dt.dayOfTheWeek())));
   Wire._I2C_WRITE(bin2bcd(dt.day()));
   Wire._I2C_WRITE(bin2bcd(dt.month()));
-  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000));
+  Wire._I2C_WRITE(bin2bcd(dt.year() - 2000U));
   Wire.endTransmission();
 
   uint8_t statreg = read_i2c_register(DS3231_ADDRESS, DS3231_STATUSREG);
@@ -1434,7 +1434,7 @@ DateTime RTC_DS3231::now() {
   Wire._I2C_READ();
   uint8_t d = bcd2bin(Wire._I2C_READ());
   uint8_t m = bcd2bin(Wire._I2C_READ());
-  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000;
+  uint16_t y = bcd2bin(Wire._I2C_READ()) + 2000U;
 
   return DateTime(y, m, d, hh, mm, ss);
 }

--- a/RTClib.h
+++ b/RTClib.h
@@ -87,7 +87,7 @@ public:
       @brief  Return the year.
       @return Year (range: 2000--2099).
   */
-  uint16_t year() const { return 2000 + yOff; }
+  uint16_t year() const { return 2000U + yOff; }
   /*!
       @brief  Return the month.
       @return Month number (1--12).


### PR DESCRIPTION
Also fix printf formatting characters from %d to %u.

Without this fix, compiling would give the following warnings:

Compiling library "RTClib"
/opt/arduino-1.8.13/hardware/tools/avr/bin/avr-g++ -c -g -Os -Wall -Wextra -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10813 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/arduino-1.8.13/hardware/arduino/avr/cores/arduino -I/opt/arduino-1.8.13/hardware/arduino/avr/variants/mega -I.../libraries/Chronos/src -I.../libraries/Time -I.../libraries/RTClib -I.../libraries/ArduinoThread -I.../libraries/SmartLCD -I/opt/arduino-1.8.13/hardware/arduino/avr/libraries/Wire/src .../libraries/RTClib/RTClib.cpp -o /tmp/arduino_build_578150/libraries/RTClib/RTClib.cpp.o
.../libraries/RTClib/RTClib.cpp: In member function 'bool DateTime::operator<(const DateTime&) const':
.../libraries/RTClib/RTClib.cpp:672:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   return (yOff + 2000 < right.year() ||
           ~~~~~~~~~~~~^~~~~~~~~~~~~~
.../libraries/RTClib/RTClib.cpp:673:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (yOff + 2000 == right.year() &&
            ~~~~~~~~~~~~^~~~~~~~~~~~~~~
.../libraries/RTClib/RTClib.cpp: In member function 'bool DateTime::operator==(const DateTime&) const':
.../libraries/RTClib/RTClib.cpp:696:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   return (right.year() == yOff + 2000 && right.month() == m &&
           ~~~~~~~~~~~~~^~~~~~~~~~~~~~