### PR TITLE
Fix reading and writing the DS3231 SQW pin mode

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1620,7 +1620,9 @@ Ds3231SqwPinMode RTC_DS3231::readSqwPinMode() {
   Wire.requestFrom((uint8_t)DS3231_ADDRESS, (uint8_t)1);
   mode = Wire._I2C_READ();
 
-  mode &= 0x93;
+  mode &= 0x1C;
+  if (mode & 0x04)
+    mode = DS3231_OFF;
   return static_cast<Ds3231SqwPinMode>(mode);
 }
 
@@ -1637,11 +1639,7 @@ void RTC_DS3231::writeSqwPinMode(Ds3231SqwPinMode mode) {
   ctrl &= ~0x04; // turn off INTCON
   ctrl &= ~0x18; // set freq bits to 0
 
-  if (mode == DS3231_OFF) {
-    ctrl |= 0x04; // turn on INTCN
-  } else {
-    ctrl |= mode;
-  }
+  ctrl |= mode;
   write_i2c_register(DS3231_ADDRESS, DS3231_CONTROL, ctrl);
 
   // Serial.println( read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL), HEX);

--- a/RTClib.h
+++ b/RTClib.h
@@ -287,7 +287,7 @@ public:
 
 /** DS3231 SQW pin mode settings */
 enum Ds3231SqwPinMode {
-  DS3231_OFF = 0x01,            /**< Off */
+  DS3231_OFF = 0x1C,            /**< Off */
   DS3231_SquareWave1Hz = 0x00,  /**<  1Hz square wave */
   DS3231_SquareWave1kHz = 0x08, /**<  1kHz square wave */
   DS3231_SquareWave4kHz = 0x10, /**<  4kHz square wave */


### PR DESCRIPTION
This pull request addresses issue #209 (RTClib does not correctly read SquareWave Pin Mode). The SQW pin mode now reflects exclusively the bits INTCN (interrupt control), and RS2:1 (rate select) of the control register. Bit mask is `0x1C`.

* `RTC_DS3231::readSqwPinMode()` now ensures that the returned value is always a valid member of the returned type (`Ds3231SqwPinMode`).
* `DS3231_OFF` is the power-on reset state of the relevant bits, i.e. all bits at logic 1.
* `RTC_DS3231::writeSqwPinMode()` is then simplified, as it doesn't need to provide special handling for `DS3231_OFF`.

Test report by @bdlabitt:
> This fix works. Just ran through the combinations and all SQW are generated and the 32K osc turns on and off as well.