### PR TITLE
Initializes "hourReformatted" and "isPM" variables

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -465,7 +465,7 @@ bool DateTime::isValid() const {
 char *DateTime::toString(char *buffer) {
   uint8_t apTag =
       (strstr(buffer, "ap") != nullptr) || (strstr(buffer, "AP") != nullptr);
-  uint8_t hourReformatted, isPM;
+  uint8_t hourReformatted = 0, isPM = false;
   if (apTag) {     // 12 Hour Mode
     if (hh == 0) { // midnight
       isPM = false;


### PR DESCRIPTION
This pull request only initializes variables "hourReformatted" and "isPM" in the toString () method.
Consequently, it removes the warnings when building the code.

![image](https://user-images.githubusercontent.com/11915449/99850842-db3b1500-2b5c-11eb-8ce3-bca2c0d8cdbb.png)
