### PR TITLE
Add missing links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ https://learn.adafruit.com/the-well-automated-arduino-library/doxygen
 https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips
 
 ## Code formatting and clang-format
-The code should be formatted according to the [LLVM Coding Standards][std], which is the default of the clang-format tool.  The easiest way to ensure conformance is to [install clang-format][llvm] and run
+The code should be formatted according to the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html), which is the default of the clang-format tool.  The easiest way to ensure conformance is to [install clang-format](https://llvm.org/builds/) and run
 
 ```shell
 clang-format -i <source_file>`


### PR DESCRIPTION
Pull request #189 added a short paragraph to README.md that explains the code formatting requirements, and shows the `clang-format` command that can be used to comply with them. It was intended to provide links to the LLVM Coding Standards and the LLVM downloads page, but hose links went missing.

This pull request adds the missing links:
* [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html)
* [install clang-format](https://llvm.org/builds/)

Note that the second link points to the snapshots provided by the LLVM project. It does not cover the more straightforward install from a package manager (apt, dnf, yum, brew...) on those OSes that package clang-format.