### PR TITLE
Correction to comment and debug string.

### DIFF
--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -60,10 +60,10 @@ void loop () {
     Serial.print(now.unixtime() / 86400L);
     Serial.println("d");
 
-    // calculate a date which is 7 days, 30 minutes, 6 seconds into the future
+    // calculate a date which is 7 days, 12 hours, 30 minutes, 6 seconds into the future
     DateTime future (now + TimeSpan(7,12,30,6));
 
-    Serial.print(" now + 7d + 30m + 6s: ");
+    Serial.print(" now + 7d + 12h + 30m + 6s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
     Serial.print(future.month(), DEC);

--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -60,10 +60,10 @@ void loop () {
     Serial.print(now.unixtime() / 86400L);
     Serial.println("d");
 
-    // calculate a date which is 7 days and 30 seconds into the future
+    // calculate a date which is 7 days, 30 minutes, 6 seconds into the future
     DateTime future (now + TimeSpan(7,12,30,6));
 
-    Serial.print(" now + 7d + 30s: ");
+    Serial.print(" now + 7d + 30m + 6s: ");
     Serial.print(future.year(), DEC);
     Serial.print('/');
     Serial.print(future.month(), DEC);


### PR DESCRIPTION
This pull request fixes a comment and debug string in the DS3231 example code 
to match the code in calculating a timestamp in the future.
Tested and working with Feather M4 Express and DS3231 RTC Feather

