### PR TITLE
changes macro to support AVR ATtiny84 with TinyWireM

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -63,9 +63,6 @@
 #endif
 
 #if (ARDUINO >= 100)
-#include <Arduino.h> // capital A so it is error prone on case-sensitive filesystems
-// Macro to deal with the difference in I2C write functions from old and new
-// Arduino versions.
 #define _I2C_WRITE write ///< Modern I2C write
 #define _I2C_READ read   ///< Modern I2C read
 #else

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -42,7 +42,7 @@
 */
 /**************************************************************************/
 
-#ifdef __AVR_ATtiny85__
+#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__)
 #include <TinyWireM.h>
 #define Wire TinyWireM
 #else

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -42,14 +42,14 @@
 */
 /**************************************************************************/
 
-#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__)
+#include "RTClib.h"
+#if defined(__AVR__) && !defined(TWCR) && defined(USICR)
 #include <TinyWireM.h>
 #define Wire TinyWireM
 #else
 #include <Wire.h>
 #endif
 
-#include "RTClib.h"
 #ifdef __AVR__
 #include <avr/pgmspace.h>
 #elif defined(ESP8266)


### PR DESCRIPTION
**Scope of change**
* this is a one-line change that opens the library to support the AVR ATtiny84 as well the AVR ATtiny85
* it updates the RTClib.cpp macros to use TinyWireM in the case of AVR ATtiny85 or AVR ATtiny84
* I tested this library with the AVR ATtiny84 / DS3231 in [EHA](https://gitlab.com/eslatt/escalator-home-automation)