### PR TITLE
abort() in line 18 resets esp8266

### DIFF
--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    
+    exit(1);
   }
 
   if (! rtc.isrunning()) {

--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    
   }
 
   if (! rtc.isrunning()) {


### PR DESCRIPTION
line 18 "abort()" send esp8266 into endless reset loop. removing it solved the problem.
I have only tested this with node mcu esp8266 v1.0