### PR TITLE
Small documentation enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips
 The code should be formatted according to the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html), which is the default of the clang-format tool.  The easiest way to ensure conformance is to [install clang-format](https://llvm.org/builds/) and run
 
 ```shell
-clang-format -i <source_file>`
+clang-format -i <source_file>
 ```
+
+See [Formatting with clang-format](https://learn.adafruit.com/the-well-automated-arduino-library/formatting-with-clang-format) for details.
 
 Written by JeeLabs
 MIT license, check license.txt for more information

--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -28,6 +28,7 @@
     - RTC_DS1307
     - RTC_DS3231
     - RTC_PCF8523
+    - RTC_PCF8563
   - RTC emulated in software; do not expect much accuracy out of these:
     - RTC_Millis is based on `millis()`
     - RTC_Micros is based on `micros()`; its drift rate can be tuned by


### PR DESCRIPTION
This pull request provides a couple of small enhancements to the documentation:

1. In README.md, section _Code formatting and clang-format_, add a link to [Formatting with clang-format][clang], a section of the excellent Adafruit's tutorial [The Well-Automated Arduino Library][ci].
2. In the main page of the Doxygen-built [reference documentation][ref], add `RTC_PCF8563` to the list of available classes.

Note that the second item will only be visible once issue #234 is fixed.

[clang]: https://learn.adafruit.com/the-well-automated-arduino-library/formatting-with-clang-format
[ci]: https://learn.adafruit.com/the-well-automated-arduino-library
[ref]: https://adafruit.github.io/RTClib/html/index.html