### PR TITLE
Make RTC_Millis and RTC_Micros non-static

### DIFF
--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -975,14 +975,6 @@ void RTC_DS1307::writenvram(uint8_t address, uint8_t data) {
   writenvram(address, &data, 1);
 }
 
-/** Alignment between the millis() timescale and the Unix timescale. These
-  two variables are updated on each call to now(), which prevents
-  rollover issues. Note that lastMillis is **not** the millis() value
-  of the last call to now(): it's the millis() value corresponding to
-  the last **full second** of Unix time. */
-uint32_t RTC_Millis::lastMillis;
-uint32_t RTC_Millis::lastUnix;
-
 /**************************************************************************/
 /*!
     @brief  Set the current date/time of the RTC_Millis clock.
@@ -1009,14 +1001,6 @@ DateTime RTC_Millis::now() {
   return lastUnix;
 }
 
-/** Number of microseconds reported by micros() per "true" (calibrated) second.
- */
-uint32_t RTC_Micros::microsPerSecond = 1000000;
-
-/** The timing logic is identical to RTC_Millis. */
-uint32_t RTC_Micros::lastMicros;
-uint32_t RTC_Micros::lastUnix;
-
 /**************************************************************************/
 /*!
     @brief  Set the current date/time of the RTC_Micros clock.
@@ -1031,10 +1015,9 @@ void RTC_Micros::adjust(const DateTime &dt) {
 /**************************************************************************/
 /*!
     @brief  Adjust the RTC_Micros clock to compensate for system clock drift
-    @param ppm Adjustment to make
+    @param ppm Adjustment to make. A positive adjustment makes the clock faster.
 */
 /**************************************************************************/
-// A positive adjustment makes the clock faster.
 void RTC_Micros::adjustDrift(int ppm) { microsPerSecond = 1000000 - ppm; }
 
 /**************************************************************************/

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -464,15 +464,27 @@ public:
       @brief  Start the RTC
       @param dt DateTime object with the date/time to set
   */
-  static void begin(const DateTime &dt) { adjust(dt); }
-  static void adjust(const DateTime &dt);
-  static DateTime now();
+  void begin(const DateTime &dt) { adjust(dt); }
+  void adjust(const DateTime &dt);
+  DateTime now();
 
 protected:
-  static uint32_t lastUnix;   ///< Unix time from the previous call to now() -
-                              ///< prevents rollover issues
-  static uint32_t lastMillis; ///< the millis() value corresponding to the last
-                              ///< **full second** of Unix time
+  /*!
+      Unix time from the previous call to now().
+
+      This, together with `lastMillis`, defines the alignment between
+      the `millis()` timescale and the Unix timescale. Both variables
+      are updated on each call to now(), which prevents rollover issues.
+  */
+  uint32_t lastUnix;
+  /*!
+      `millis()` value corresponding `lastUnix`.
+
+      Note that this is **not** the `millis()` value of the last call to
+      now(): it's the `millis()` value corresponding to the last **full
+      second** of Unix time preceding the last call to now().
+  */
+  uint32_t lastMillis;
 };
 
 /**************************************************************************/
@@ -490,18 +502,27 @@ public:
       @brief  Start the RTC
       @param dt DateTime object with the date/time to set
   */
-  static void begin(const DateTime &dt) { adjust(dt); }
-  static void adjust(const DateTime &dt);
-  static void adjustDrift(int ppm);
-  static DateTime now();
+  void begin(const DateTime &dt) { adjust(dt); }
+  void adjust(const DateTime &dt);
+  void adjustDrift(int ppm);
+  DateTime now();
 
 protected:
-  static uint32_t microsPerSecond; ///< Number of microseconds reported by
-                                   ///< micros() per "true" (calibrated) second
-  static uint32_t lastUnix;   ///< Unix time from the previous call to now() -
-                              ///< prevents rollover issues
-  static uint32_t lastMicros; ///< micros() value corresponding to the last full
-                              ///< second of Unix time
+  /*!
+      Number of microseconds reported by `micros()` per "true"
+      (calibrated) second.
+  */
+  uint32_t microsPerSecond = 1000000;
+  /*!
+      Unix time from the previous call to now().
+
+      The timing logic is identical to RTC_Millis.
+  */
+  uint32_t lastUnix;
+  /*!
+      `micros()` value corresponding to `lastUnix`.
+  */
+  uint32_t lastMicros;
 };
 
 #endif // _RTCLIB_H_


### PR DESCRIPTION
The data members and methods of these classes were all made `static`, for consistency with the other RTC classes.

Commit 836a2bcd97fb4e3b38d6fb79f48106a66682e7a0 converted all the `static` data members of the “real RTC” classes into instance members, and made all methods non-static. This pull request does the same for `RTC_Millis` and `RTC_Micros`, for the sake of maintaining consistency, with the added benefit that multiple independent instances of each can now be created.