### PR TITLE
Fix the build of reference documen

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -29,4 +29,4 @@ jobs:
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "RTClib"
-      run: bash ci/doxy_gen_and_deploy.sh
+      run: bash ci/doxy_gen_and_deploy.sh src

--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -808,6 +808,7 @@ static uint8_t bin2bcd(uint8_t val) { return val + 6 * (val / 10); }
 /**************************************************************************/
 /*!
     @brief  Start I2C for the DS1307 and test succesful connection
+    @param  wireInstance pointer to the I2C bus
     @return True if Wire can find DS1307 or false otherwise.
 */
 /**************************************************************************/
@@ -1053,6 +1054,7 @@ DateTime RTC_Micros::now() {
 /**************************************************************************/
 /*!
     @brief  Start I2C for the PCF8523 and test succesful connection
+    @param  wireInstance pointer to the I2C bus
     @return True if Wire can find PCF8523 or false otherwise.
 */
 /**************************************************************************/
@@ -1402,6 +1404,7 @@ void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
 /**************************************************************************/
 /*!
     @brief  Start I2C for the PCF8563 and test succesful connection
+    @param  wireInstance pointer to the I2C bus
     @return True if Wire can find PCF8563 or false otherwise.
 */
 /**************************************************************************/
@@ -1564,6 +1567,7 @@ static uint8_t dowToDS3231(uint8_t d) { return d == 0 ? 7 : d; }
 /**************************************************************************/
 /*!
     @brief  Start I2C for the DS3231 and test succesful connection
+    @param  wireInstance pointer to the I2C bus
     @return True if Wire can find DS3231 or false otherwise.
 */
 /**************************************************************************/

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -287,7 +287,7 @@ public:
   void writenvram(uint8_t address, uint8_t *buf, uint8_t size);
 
 protected:
-  TwoWire *RTCWireBus;
+  TwoWire *RTCWireBus; ///< I2C bus connected to the RTC
 };
 
 /** DS3231 SQW pin mode settings */
@@ -347,7 +347,7 @@ public:
   float getTemperature(); // in Celsius degree
 
 protected:
-  TwoWire *RTCWireBus;
+  TwoWire *RTCWireBus; ///< I2C bus connected to the RTC
 };
 
 /** PCF8523 INT/SQW pin mode settings */
@@ -418,7 +418,7 @@ public:
   void calibrate(Pcf8523OffsetMode mode, int8_t offset);
 
 protected:
-  TwoWire *RTCWireBus;
+  TwoWire *RTCWireBus; ///< I2C bus connected to the RTC
 };
 
 /** PCF8563 CLKOUT pin mode settings */
@@ -449,7 +449,7 @@ public:
   void writeSqwPinMode(Pcf8563SqwPinMode mode);
 
 protected:
-  TwoWire *RTCWireBus;
+  TwoWire *RTCWireBus; ///< I2C bus connected to the RTC
 };
 
 /**************************************************************************/


### PR DESCRIPTION
As mentioned in issue #234, the [reference documentation][doc] has vanished since the merge of pull request #231.

This pull request fixes the issue by providing the name of the source directory (`src`) as a parameter to the script that runs Doxygen. The first commit adds some missing documentation comments, without which the Doxygen script would fail.

This [has been tested][run] on my fork.

[doc]: https://adafruit.github.io/RTClib/html/index.html
[run]: https://github.com/edgar-bonet/RTClib/runs/3209811061
