### PR TITLE
Remove vestigial pre-processor code

### DIFF
--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -44,12 +44,6 @@
 /**************************************************************************/
 
 #include "RTClib.h"
-#if defined(__AVR__) && !defined(TWCR) && defined(USICR)
-#include <TinyWireM.h>
-#define Wire TinyWireM
-#else
-#include <Wire.h>
-#endif
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
@@ -60,7 +54,6 @@
 #elif defined(ARDUINO_SAM_DUE)
 #define PROGMEM
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
-#define Wire Wire1
 #endif
 
 #if (ARDUINO >= 100)


### PR DESCRIPTION
This pull request is a follow-up on the discussion on issue #239.

Since version 1.14.0 (specifically, since commit ae29ca906c5483dee6c2d4e492c73b0c9c262110), the default I2C port is `Wire` on all platforms. The pre-processor code that used to select a platform-dependent I2C port is still there, but it has become dead code. This can [cause some confusion][se]. Removing this dead code should make things clearer.

Note that Wire.h is included by RTClib.cpp via RTClib.h.

[se]: https://arduino.stackexchange.com/questions/86079