### PR TITLE
Fix ESP8266 WDT resets and DS3231 century bit issue

### DIFF
--- a/examples/DS3231_alarm/DS3231_alarm.ino
+++ b/examples/DS3231_alarm/DS3231_alarm.ino
@@ -21,34 +21,34 @@ void setup() {
     if(!rtc.begin()) {
         Serial.println("Couldn't find RTC!");
         Serial.flush();
-        abort();
+        while (1) delay(10);
     }
-    
+
     if(rtc.lostPower()) {
         // this will adjust to the date and time at compilation
         rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
     }
-    
+
     //we don't need the 32K Pin, so disable it
     rtc.disable32K();
-    
+
     // Making it so, that the alarm will trigger an interrupt
     pinMode(CLOCK_INTERRUPT_PIN, INPUT_PULLUP);
     attachInterrupt(digitalPinToInterrupt(CLOCK_INTERRUPT_PIN), onAlarm, FALLING);
-    
+
     // set alarm 1, 2 flag to false (so alarm 1, 2 didn't happen so far)
     // if not done, this easily leads to problems, as both register aren't reset on reboot/recompile
     rtc.clearAlarm(1);
     rtc.clearAlarm(2);
-    
+
     // stop oscillating signals at SQW Pin
     // otherwise setAlarm1 will fail
     rtc.writeSqwPinMode(DS3231_OFF);
-    
+
     // turn off alarm 2 (in case it isn't off already)
     // again, this isn't done at reboot, so a previously set alarm could easily go overlooked
     rtc.disableAlarm(2);
-    
+
     // schedule an alarm 10 seconds in the future
     if(!rtc.setAlarm1(
             rtc.now() + TimeSpan(10),
@@ -56,7 +56,7 @@ void setup() {
     )) {
         Serial.println("Error, alarm wasn't set!");
     }else {
-        Serial.println("Alarm will happen in 10 seconds!");  
+        Serial.println("Alarm will happen in 10 seconds!");
     }
 }
 
@@ -76,14 +76,14 @@ void loop() {
     // control register values (see https://datasheets.maximintegrated.com/en/ds/DS3231.pdf page 13)
     // Serial.print(" Control: 0b");
     // Serial.println(read_i2c_register(DS3231_ADDRESS, DS3231_CONTROL), BIN);
-    
+
     // resetting SQW and alarm 1 flag
     // using setAlarm1, the next alarm could now be configurated
     if(rtc.alarmFired(1)) {
         rtc.clearAlarm(1);
         Serial.println("Alarm cleared");
     }
-    
+
     delay(2000);
 }
 

--- a/examples/ds1307/ds1307.ino
+++ b/examples/ds1307/ds1307.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (! rtc.isrunning()) {

--- a/examples/ds1307SqwPin/ds1307SqwPin.ino
+++ b/examples/ds1307SqwPin/ds1307SqwPin.ino
@@ -45,7 +45,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   print_mode();

--- a/examples/ds1307nvram/ds1307nvram.ino
+++ b/examples/ds1307nvram/ds1307nvram.ino
@@ -23,7 +23,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   // Print old RAM contents on startup.

--- a/examples/ds3231/ds3231.ino
+++ b/examples/ds3231/ds3231.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (rtc.lostPower()) {

--- a/examples/interrupts1Hz/interrupts1Hz.ino
+++ b/examples/interrupts1Hz/interrupts1Hz.ino
@@ -59,7 +59,7 @@ void setup() {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
   if (!rtc.initialized() || rtc.lostPower()) {
     rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));

--- a/examples/pcf8523/pcf8523.ino
+++ b/examples/pcf8523/pcf8523.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (! rtc.initialized() || rtc.lostPower()) {
@@ -44,7 +44,7 @@ void setup () {
   // to be restarted by clearing the STOP bit. Let's do this to ensure
   // the RTC is running.
   rtc.start();
-  
+
    // The PCF8523 can be calibrated for:
   //        - Aging adjustment
   //        - Temperature compensation

--- a/examples/pcf8523Countdown/pcf8523Countdown.ino
+++ b/examples/pcf8523Countdown/pcf8523Countdown.ino
@@ -42,7 +42,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/pcf8563/pcf8563.ino
+++ b/examples/pcf8563/pcf8563.ino
@@ -15,7 +15,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (rtc.lostPower()) {

--- a/examples/pcf8563_interrupt/pcf8563_interrupt.ino
+++ b/examples/pcf8563_interrupt/pcf8563_interrupt.ino
@@ -6,7 +6,7 @@ RTC_PCF8563 rtc;
 char daysOfTheWeek[7][12] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
 // use D2 for INT0; attach to CLKOUT pin on RTC
-const uint8_t INT_PIN = 2; 
+const uint8_t INT_PIN = 2;
 
 // flag to update serial; set in interrupt callback
 volatile uint8_t tick_tock = 1;
@@ -23,7 +23,7 @@ void setup () {
   while (!Serial); // wait for serial port to connect. Needed for native USB
 #endif
 
-  
+
   pinMode(INT_PIN, INPUT);        // set up interrupt pin
   digitalWrite(INT_PIN, HIGH);    // turn on pullup resistors
   // attach interrupt to set_tick_tock callback on rising edge of INT0
@@ -32,7 +32,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (rtc.lostPower()) {
@@ -51,7 +51,7 @@ void setup () {
   }
 
 
-  
+
   // When time needs to be re-set on a previously configured device, the
   // following line sets the RTC to the date & time this sketch was compiled
   // rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
@@ -63,7 +63,7 @@ void setup () {
   // to be restarted by clearing the STOP bit. Let's do this to ensure
   // the RTC is running.
   rtc.start();
-    
+
   // turn on 1Hz clock out, used as INT0 for serial update every second
   rtc.writeSqwPinMode(PCF8563_SquareWave1Hz);
 }
@@ -72,7 +72,7 @@ void loop () {
 
   // check if time display should be output
   if(tick_tock) {
- 
+
     DateTime now = rtc.now();
 
     char time_format[] = "hh:mm:ss AP";
@@ -81,7 +81,7 @@ void loop () {
     Serial.println(now.toString(time_format));
     Serial.println(now.toString(date_format));
     Serial.println();
- 
+
     tick_tock = 0;
 
   }

--- a/examples/timestamp/timestamp.ino
+++ b/examples/timestamp/timestamp.ino
@@ -22,7 +22,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (! rtc.isrunning()) {

--- a/examples/toString/toString.ino
+++ b/examples/toString/toString.ino
@@ -14,7 +14,7 @@ void setup () {
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     Serial.flush();
-    abort();
+    while (1) delay(10);
   }
 
   if (! rtc.isrunning()) {

--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -71,7 +71,7 @@ DateTime RTC_DS3231::now() {
   buffer[0] = 0;
   i2c_dev->write_then_read(buffer, 1, buffer, 7);
 
-  return DateTime(bcd2bin(buffer[6]) + 2000U, bcd2bin(buffer[5]),
+  return DateTime(bcd2bin(buffer[6]) + 2000U, bcd2bin(buffer[5] & 0x7F),
                   bcd2bin(buffer[4]), bcd2bin(buffer[2]), bcd2bin(buffer[1]),
                   bcd2bin(buffer[0] & 0x7F));
 }


### PR DESCRIPTION
A couple of misc fixes:
* Change `abort()` in examples to loop with delay to prevent WDT reset on ESP8266. This replaces PR #224.
* Mask out century bit in DS3231 month register for Issue #71.