### PR TITLE
Improve const correctness

### DIFF
--- a/src/RTC_DS1307.cpp
+++ b/src/RTC_DS1307.cpp
@@ -104,7 +104,7 @@ void RTC_DS1307::readnvram(uint8_t *buf, uint8_t size, uint8_t address) {
     @param size Number of bytes in buf to write to NVRAM
 */
 /**************************************************************************/
-void RTC_DS1307::writenvram(uint8_t address, uint8_t *buf, uint8_t size) {
+void RTC_DS1307::writenvram(uint8_t address, const uint8_t *buf, uint8_t size) {
   uint8_t addrByte = DS1307_NVRAM + address;
   i2c_dev->write(buf, size, true, &addrByte, 1);
 }

--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -601,7 +601,7 @@ uint32_t DateTime::secondstime(void) const {
     @return New DateTime object with span added to it.
 */
 /**************************************************************************/
-DateTime DateTime::operator+(const TimeSpan &span) {
+DateTime DateTime::operator+(const TimeSpan &span) const {
   return DateTime(unixtime() + span.totalseconds());
 }
 
@@ -612,7 +612,7 @@ DateTime DateTime::operator+(const TimeSpan &span) {
     @return New DateTime object with span subtracted from it.
 */
 /**************************************************************************/
-DateTime DateTime::operator-(const TimeSpan &span) {
+DateTime DateTime::operator-(const TimeSpan &span) const {
   return DateTime(unixtime() - span.totalseconds());
 }
 
@@ -628,7 +628,7 @@ DateTime DateTime::operator-(const TimeSpan &span) {
     @return TimeSpan of the difference between DateTimes.
 */
 /**************************************************************************/
-TimeSpan DateTime::operator-(const DateTime &right) {
+TimeSpan DateTime::operator-(const DateTime &right) const {
   return TimeSpan(unixtime() - right.unixtime());
 }
 
@@ -689,7 +689,7 @@ bool DateTime::operator==(const DateTime &right) const {
     @return Timestamp string, e.g. "2020-04-16T18:34:56".
 */
 /**************************************************************************/
-String DateTime::timestamp(timestampOpt opt) {
+String DateTime::timestamp(timestampOpt opt) const {
   char buffer[25]; // large enough for any DateTime, including invalid ones
 
   // Generate timestamp according to opt
@@ -748,7 +748,7 @@ TimeSpan::TimeSpan(const TimeSpan &copy) : _seconds(copy._seconds) {}
     @return New TimeSpan object, sum of left and right
 */
 /**************************************************************************/
-TimeSpan TimeSpan::operator+(const TimeSpan &right) {
+TimeSpan TimeSpan::operator+(const TimeSpan &right) const {
   return TimeSpan(_seconds + right._seconds);
 }
 
@@ -759,6 +759,6 @@ TimeSpan TimeSpan::operator+(const TimeSpan &right) {
     @return New TimeSpan object, right subtracted from left
 */
 /**************************************************************************/
-TimeSpan TimeSpan::operator-(const TimeSpan &right) {
+TimeSpan TimeSpan::operator-(const TimeSpan &right) const {
   return TimeSpan(_seconds - right._seconds);
 }

--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -438,7 +438,7 @@ bool DateTime::isValid() const {
 */
 /**************************************************************************/
 
-char *DateTime::toString(char *buffer) {
+char *DateTime::toString(char *buffer) const {
   uint8_t apTag =
       (strstr(buffer, "ap") != nullptr) || (strstr(buffer, "AP") != nullptr);
   uint8_t hourReformatted = 0, isPM = false;

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -207,11 +207,11 @@ public:
     TIMESTAMP_TIME, //!< `hh:mm:ss`
     TIMESTAMP_DATE  //!< `YYYY-MM-DD`
   };
-  String timestamp(timestampOpt opt = TIMESTAMP_FULL);
+  String timestamp(timestampOpt opt = TIMESTAMP_FULL) const;
 
-  DateTime operator+(const TimeSpan &span);
-  DateTime operator-(const TimeSpan &span);
-  TimeSpan operator-(const DateTime &right);
+  DateTime operator+(const TimeSpan &span) const;
+  DateTime operator-(const TimeSpan &span) const;
+  TimeSpan operator-(const DateTime &right) const;
   bool operator<(const DateTime &right) const;
 
   /*!
@@ -311,8 +311,8 @@ public:
   */
   int32_t totalseconds() const { return _seconds; }
 
-  TimeSpan operator+(const TimeSpan &right);
-  TimeSpan operator-(const TimeSpan &right);
+  TimeSpan operator+(const TimeSpan &right) const;
+  TimeSpan operator-(const TimeSpan &right) const;
 
 protected:
   int32_t _seconds; ///< Actual TimeSpan value is stored as seconds
@@ -359,7 +359,7 @@ public:
   uint8_t readnvram(uint8_t address);
   void readnvram(uint8_t *buf, uint8_t size, uint8_t address);
   void writenvram(uint8_t address, uint8_t data);
-  void writenvram(uint8_t address, uint8_t *buf, uint8_t size);
+  void writenvram(uint8_t address, const uint8_t *buf, uint8_t size);
 };
 
 /**************************************************************************/

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -150,7 +150,7 @@ public:
   DateTime(const __FlashStringHelper *date, const __FlashStringHelper *time);
   DateTime(const char *iso8601date);
   bool isValid() const;
-  char *toString(char *buffer);
+  char *toString(char *buffer) const;
 
   /*!
       @brief  Return the year.


### PR DESCRIPTION
As noted in issue #249, the library could use some more `const` qualifiers. This pull request adds the ones I could find missing.

Fixes #249.