### PR TITLE
Replace `boolean` type by `bool`

### DIFF
--- a/src/RTC_DS1307.cpp
+++ b/src/RTC_DS1307.cpp
@@ -11,7 +11,7 @@
     @return True if Wire can find DS1307 or false otherwise.
 */
 /**************************************************************************/
-boolean RTC_DS1307::begin(TwoWire *wireInstance) {
+bool RTC_DS1307::begin(TwoWire *wireInstance) {
   if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(DS1307_ADDRESS, wireInstance);

--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -17,7 +17,7 @@
     @return True if Wire can find DS3231 or false otherwise.
 */
 /**************************************************************************/
-boolean RTC_DS3231::begin(TwoWire *wireInstance) {
+bool RTC_DS3231::begin(TwoWire *wireInstance) {
   if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(DS3231_ADDRESS, wireInstance);

--- a/src/RTC_PCF8523.cpp
+++ b/src/RTC_PCF8523.cpp
@@ -17,7 +17,7 @@
     @return True if Wire can find PCF8523 or false otherwise.
 */
 /**************************************************************************/
-boolean RTC_PCF8523::begin(TwoWire *wireInstance) {
+bool RTC_PCF8523::begin(TwoWire *wireInstance) {
   if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(PCF8523_ADDRESS, wireInstance);
@@ -37,7 +37,7 @@ boolean RTC_PCF8523::begin(TwoWire *wireInstance) {
    after the bit is cleared, for instance with adjust()
 */
 /**************************************************************************/
-boolean RTC_PCF8523::lostPower(void) {
+bool RTC_PCF8523::lostPower(void) {
   return read_register(PCF8523_STATUSREG) >> 7;
 }
 
@@ -48,7 +48,7 @@ boolean RTC_PCF8523::lostPower(void) {
     @return True if the PCF8523 has been set up, false if not
 */
 /**************************************************************************/
-boolean RTC_PCF8523::initialized(void) {
+bool RTC_PCF8523::initialized(void) {
   return (read_register(PCF8523_CONTROL_3) & 0xE0) != 0xE0;
 }
 

--- a/src/RTC_PCF8563.cpp
+++ b/src/RTC_PCF8563.cpp
@@ -14,7 +14,7 @@
     @return True if Wire can find PCF8563 or false otherwise.
 */
 /**************************************************************************/
-boolean RTC_PCF8563::begin(TwoWire *wireInstance) {
+bool RTC_PCF8563::begin(TwoWire *wireInstance) {
   if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(PCF8563_ADDRESS, wireInstance);
@@ -34,7 +34,7 @@ boolean RTC_PCF8563::begin(TwoWire *wireInstance) {
     cleared using adjust()
 */
 /**************************************************************************/
-boolean RTC_PCF8563::lostPower(void) {
+bool RTC_PCF8563::lostPower(void) {
   return read_register(PCF8563_VL_SECONDS) >> 7;
 }
 

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -350,7 +350,7 @@ protected:
 /**************************************************************************/
 class RTC_DS1307 : RTC_I2C {
 public:
-  boolean begin(TwoWire *wireInstance = &Wire);
+  bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
   uint8_t isrunning(void);
   DateTime now();
@@ -369,7 +369,7 @@ public:
 /**************************************************************************/
 class RTC_DS3231 : RTC_I2C {
 public:
-  boolean begin(TwoWire *wireInstance = &Wire);
+  bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
   bool lostPower(void);
   DateTime now();
@@ -401,10 +401,10 @@ public:
 /**************************************************************************/
 class RTC_PCF8523 : RTC_I2C {
 public:
-  boolean begin(TwoWire *wireInstance = &Wire);
+  bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
-  boolean lostPower(void);
-  boolean initialized(void);
+  bool lostPower(void);
+  bool initialized(void);
   DateTime now();
   void start(void);
   void stop(void);
@@ -428,8 +428,8 @@ public:
 /**************************************************************************/
 class RTC_PCF8563 : RTC_I2C {
 public:
-  boolean begin(TwoWire *wireInstance = &Wire);
-  boolean lostPower(void);
+  bool begin(TwoWire *wireInstance = &Wire);
+  bool lostPower(void);
   void adjust(const DateTime &dt);
   DateTime now();
   void start(void);


### PR DESCRIPTION
The `boolean` type [is being phased out][issue] by the Arduino team in favor of the standard `bool` type. According to [the Arduino documentation of `boolean`][doc]:

> It’s recommended to instead use the standard type `bool`, which is identical.

This pull request replaces every occurrence of `boolean` by `bool`.

[issue]: https://github.com/arduino/Arduino/issues/4673
[doc]: https://www.arduino.cc/reference/en/language/variables/data-types/boolean/