### PR TITLE
Fix CI failure due to unused variables

### DIFF
--- a/examples/DS3231_alarm/DS3231_alarm.ino
+++ b/examples/DS3231_alarm/DS3231_alarm.ino
@@ -70,11 +70,11 @@ void loop() {
     DateTime alarm1 = rtc.getAlarm1();
     Ds3231Alarm1Mode alarm1mode = rtc.getAlarm1Mode();
     char alarm1Date[12] = "DD hh:mm:ss";
-    rtc.getAlarm1().toString(alarm1Date);
+    alarm1.toString(alarm1Date);
     Serial.print(" [Alarm1: ");
     Serial.print(alarm1Date);
     Serial.print(", Mode: ");
-    switch (rtc.getAlarm1Mode()) {
+    switch (alarm1mode) {
       case DS3231_A1_PerSecond: Serial.print("PerSecond"); break;
       case DS3231_A1_Second: Serial.print("Second"); break;
       case DS3231_A1_Minute: Serial.print("Minute"); break;


### PR DESCRIPTION
Since the merge of PR #257, the CI workflow has been failing in “test platforms”. The failure is due to errors while compiling the example sketch DS3231\_alarm.ino on ESP32:

```text
DS3231_alarm.ino:70:14: error: variable 'alarm1' set but not used [-Werror=unused-but-set-variable]
       DateTime alarm1 = rtc.getAlarm1();
                ^~~~~~
DS3231_alarm.ino:71:22: error: unused variable 'alarm1mode' [-Werror=unused-variable]
       Ds3231Alarm1Mode alarm1mode = rtc.getAlarm1Mode();
                        ^~~~~~~~~~
  cc1plus: some warnings being treated as errors
```

On the other platforms being tested, the same warnings show up. However, only the ESP32 toolchain is promoting warnings to errors.

Fix this by using the variables instead of recomputing their values later.