### PR TITLE
DS3231: Add support for fetching alarm enabled status

### DIFF
--- a/examples/DS3231_alarm/DS3231_alarm.ino
+++ b/examples/DS3231_alarm/DS3231_alarm.ino
@@ -87,8 +87,12 @@ void loop() {
     Serial.print("] SQW: ");
     Serial.print(digitalRead(CLOCK_INTERRUPT_PIN));
 
-    // whether a alarm fired
-    Serial.print(" Fired: ");
+    // indicates if alarm 1 is enabled
+    Serial.print(", Enabled: ");
+    Serial.print(rtc.alarmEnabled(1));
+
+    // whether alarm 1 fired
+    Serial.print(", Fired: ");
     Serial.print(rtc.alarmFired(1));
 
     // Serial.print(" Alarm2: ");

--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -340,8 +340,19 @@ void RTC_DS3231::clearAlarm(uint8_t alarm_num) {
 
 /**************************************************************************/
 /*!
-    @brief  Get status of alarm
-        @param 	alarm_num Alarm number to check status of
+    @brief  Get enabled status of alarm
+        @param 	alarm_num Alarm number to check enabled status of
+        @return True if alarm is enabled otherwise false
+*/
+/**************************************************************************/
+bool RTC_DS3231::alarmEnabled(uint8_t alarm_num) {
+  return (read_register(DS3231_CONTROL) >> (alarm_num - 1)) & 0x1;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Get fired status of alarm
+        @param 	alarm_num Alarm number to check fired status of
         @return True if alarm has been fired otherwise false
 */
 /**************************************************************************/

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -383,6 +383,7 @@ public:
   Ds3231Alarm2Mode getAlarm2Mode();
   void disableAlarm(uint8_t alarm_num);
   void clearAlarm(uint8_t alarm_num);
+  bool alarmEnabled(uint8_t alarm_num);
   bool alarmFired(uint8_t alarm_num);
   void enable32K(void);
   void disable32K(void);


### PR DESCRIPTION
This commit introduces one new method for DS3231 devices:
  - bool alarmEnabled(uint8_t alarm_num);

Updated the DS3231_alarm example to fetch the alarm1 enabled status.
Locally validated that this correctly fetches the enabled/disabled status
for alarm2 as well.

**Sample output from the DS3231_alarm example**
```
22:43:32 [Alarm1: 20 22:43:36, Mode: Second, Enabled: 1, Fired: 0
22:43:34 [Alarm1: 20 22:43:36, Mode: Second, Enabled: 1, Fired: 0
22:43:36 [Alarm1: 20 22:43:36, Mode: Second, Enabled: 1, Fired: 1 - Alarm cleared
22:43:38 [Alarm1: 20 22:43:36, Mode: Second, Enabled: 1, Fired: 0
22:43:40 [Alarm1: 20 22:43:36, Mode: Second, Enabled: 1, Fired: 0
```
The `Enabled: 1` is what is new 😄 
