### PR TITLE
Add function isPresent() to check if i2c connection has been established

### DIFF
--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -324,6 +324,13 @@ protected:
 */
 /**************************************************************************/
 class RTC_I2C {
+public:
+  /*!
+      @brief  Check if I2C device is present
+      @return true if present, false otherwise
+  */
+  bool isPresent(void) { return i2c_dev != NULL; };
+
 protected:
   /*!
       @brief  Convert a binary coded decimal value to binary. RTC stores
@@ -348,7 +355,7 @@ protected:
     @brief  RTC based on the DS1307 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS1307 : RTC_I2C {
+class RTC_DS1307 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -367,7 +374,7 @@ public:
     @brief  RTC based on the DS3231 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS3231 : RTC_I2C {
+class RTC_DS3231 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -403,7 +410,7 @@ public:
     @brief  RTC based on the PCF8523 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8523 : RTC_I2C {
+class RTC_PCF8523 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -430,7 +437,7 @@ public:
     @brief  RTC based on the PCF8563 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8563 : RTC_I2C {
+class RTC_PCF8563 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   bool lostPower(void);


### PR DESCRIPTION
The current implementation of i2Clib provides no way, to check "on demand" if the i2c device has been connected and initialized. The only way is the return value of the "begin" function. 

However, the protected variable "i2c_dev" in the class "RTC_I2C" does contain this information. If it is "NULL", the device has not been initialized. 

Therefore, I added a function to "RTC_I2C" to check if this variable is NULL or not. Unfortunately, all classes derived from RTC_I2C must be derived "public". Otherwise, the variable is not visible to code outside the derived classes.