### PR TITLE
DS3231: Add support for the Aging Offset Register

### DIFF
--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -6,6 +6,7 @@
 #define DS3231_ALARM2 0x0B    ///< Alarm 2 register
 #define DS3231_CONTROL 0x0E   ///< Control register
 #define DS3231_STATUSREG 0x0F ///< Status register
+#define DS3231_AGINGREG 0x10  ///< Aging offset register
 #define DS3231_TEMPERATUREREG                                                  \
   0x11 ///< Temperature register (high byte - low byte is at 0x12), 10-bit
        ///< temperature value
@@ -381,4 +382,28 @@ void RTC_DS3231::disable32K(void) {
 /**************************************************************************/
 bool RTC_DS3231::isEnabled32K(void) {
   return (read_register(DS3231_STATUSREG) >> 0x03) & 0x01;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Get the value of the Aging Offset Register
+    @see    setAgingOffset() for an explanation of this register
+    @return The current value of the Aging Offset Register
+*/
+/**************************************************************************/
+int8_t RTC_DS3231::getAgingOffset() { return read_register(DS3231_AGINGREG); }
+
+/**************************************************************************/
+/*!
+    @brief  Update the Aging Offset Register
+    @details The Aging Offset Register can be used to compensate for
+             systematic drift due to aging. A positive value makes the RTC
+             run slower, a negative value makes it run faster. The effect is
+             temperature dependent. At room temperature, the RTC frequency
+             changes by roughly 0.1 ppm per unit of offset.
+    @param  offset New offset to be written into the register
+*/
+/**************************************************************************/
+void RTC_DS3231::setAgingOffset(int8_t offset) {
+  write_register(DS3231_AGINGREG, offset);
 }

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -388,6 +388,8 @@ public:
   void disable32K(void);
   bool isEnabled32K(void);
   float getTemperature(); // in Celsius degree
+  int8_t getAgingOffset();
+  void setAgingOffset(int8_t);
   /*!
       @brief  Convert the day of the week to a representation suitable for
               storing in the DS3231: from 1 (Monday) to 7 (Sunday).


### PR DESCRIPTION
The DS3231 has an “aging offset” register that can be used to finely trim the frequency of the oscillator, and hence compensate for any frequency inaccuracy that may come as the resonator ages. Advanced users can measure the drift rate of their RTC by comparing with a reliable reference, then use this register to calibrate-out that drift.

This pull request adds support for using the Aging Offset register. It adds the following methods to the class `RTC_DS3231`:

```c++
int8_t getAgingOffset();
void setAgingOffset(int8_t offset);
```

as well as Doxygen comments explaining what this register is about.

These methods were tested by @terrypin999 (see #299) using the sketch below (`#ifdef`ed-out code removed):

<details><summary>Source code (click to expand/collapse)</summary>

```c++
#include <RTClib.h>

RTC_DS3231 rtc;

const char help[] = "Available commands:\n\r"
        "  h: print this help\n\r"
        "  t: toggle printing RTC times\n\r"
        "  f: make the RTC fast\n\r"
        "  s: make the RTC slow\n\r"
        "  p: print the aging offset";

void setup() {
    rtc.begin();
    Serial.begin(9600);
    Serial.println("Ready.");
    Serial.println(help);
}

void loop() {
    /* Print RTC updates if asked to do so. */
    static bool do_print_times = false;
    if (do_print_times) {
        static DateTime last_printed_time;
        DateTime now = rtc.now();
        if (now != last_printed_time) {
            char buffer[] = "hh:mm:ss";
            Serial.println(now.toString(buffer));
            last_printed_time = now;
        }
    }

    /* Execute commands from the serial port. */
    switch (Serial.read()) {
        case 'h': Serial.println(help); break;
        case 't': do_print_times = !do_print_times; break;
        case 'f':
            Serial.println("setting aging offset to -128 (fast)");
            rtc.setAgingOffset(-128);
            break;
        case 's':
            Serial.println("setting aging offset to +127 (slow)");
            rtc.setAgingOffset(+127);
            break;
        case 'p':
            Serial.print("aging offset: ");
            Serial.println(rtc.getAgingOffset());
    }
}
```

</details>

Fixes #299.