### PR TITLE
RTC_DS3231: correctly handle negative temperatures

### DIFF
--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -114,7 +114,8 @@ void RTC_DS3231::writeSqwPinMode(Ds3231SqwPinMode mode) {
 float RTC_DS3231::getTemperature() {
   uint8_t buffer[2] = {DS3231_TEMPERATUREREG, 0};
   i2c_dev->write_then_read(buffer, 1, buffer, 2);
-  return (float)buffer[0] + (buffer[1] >> 6) * 0.25f;
+  int16_t temp = uint16_t(buffer[0]) << 8 | buffer[1];
+  return temp * (1 / 256.0);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
As reported in issue #287, the method `RTC_DS3231::getTemperature()` fails on negative temperatures. This is because the conversion from raw bytes to a `float`-typed temperature assumes the value is always positive, wheres [the datasheet specifies it is stored as a signed, two's complement integer][datasheet].

This pull request fixes the method by changing the conversion code to this:

```c++
  int16_t temp = uint16_t(buffer[0]) << 8 | buffer[1];
  return temp * (1 / 256.0);
```

Some points worth noting:

* Casting `buffer[0]` to an unsigned type is meant to avoid signed integer overflow, which is undefined behavior in C++.

* Assigning the result to a signed integer makes numbers with the most significant bit set be interpreted as negative. There is no extra work to do, as all current processors use two’s complement representation internally.

* Multiplying by `1 / 256.0` (rather than `1 / 4.0`) obviates the need for the 6-bit shift. Also, `1 / 256.0` being a compile-time constant, there is no division performed at run-time (which would be expensive).

* This code also reduces the number of floating-point operations to only two (int-to-float conversion and multiplication), v.s. four in the original code (two int-to-float conversions, one multiplication and one addition).

Tested down to −27.00°C by @i440bx.

Fixes #287.

[datasheet]: https://www.analog.com/media/en/technical-documentation/data-sheets/DS3231.pdf#page=15