### PR TITLE
Public inheritance of base class RTC_I2C for the class definitions of RTC_DS1307; RTC_DS3231; RTC_PCF8523; ...

### DIFF
--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -127,9 +127,6 @@ float RTC_DS3231::getTemperature() {
 /**************************************************************************/
 bool RTC_DS3231::setAlarm1(const DateTime &dt, Ds3231Alarm1Mode alarm_mode) {
   uint8_t ctrl = read_register(DS3231_CONTROL);
-  if (!(ctrl & 0x04)) {
-    return false;
-  }
 
   uint8_t A1M1 = (alarm_mode & 0x01) << 7; // Seconds bit 7.
   uint8_t A1M2 = (alarm_mode & 0x02) << 6; // Minutes bit 7.
@@ -160,9 +157,6 @@ bool RTC_DS3231::setAlarm1(const DateTime &dt, Ds3231Alarm1Mode alarm_mode) {
 /**************************************************************************/
 bool RTC_DS3231::setAlarm2(const DateTime &dt, Ds3231Alarm2Mode alarm_mode) {
   uint8_t ctrl = read_register(DS3231_CONTROL);
-  if (!(ctrl & 0x04)) {
-    return false;
-  }
 
   uint8_t A2M2 = (alarm_mode & 0x01) << 7; // Minutes bit 7.
   uint8_t A2M3 = (alarm_mode & 0x02) << 6; // Hour bit 7.

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -348,7 +348,7 @@ protected:
     @brief  RTC based on the DS1307 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS1307 : RTC_I2C {
+class RTC_DS1307 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -367,7 +367,7 @@ public:
     @brief  RTC based on the DS3231 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS3231 : RTC_I2C {
+class RTC_DS3231 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -403,7 +403,7 @@ public:
     @brief  RTC based on the PCF8523 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8523 : RTC_I2C {
+class RTC_PCF8523 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -430,7 +430,7 @@ public:
     @brief  RTC based on the PCF8563 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8563 : RTC_I2C {
+class RTC_PCF8563 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   bool lostPower(void);

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -348,7 +348,7 @@ protected:
     @brief  RTC based on the DS1307 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS1307 : RTC_I2C {
+class RTC_DS1307 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -367,7 +367,7 @@ public:
     @brief  RTC based on the DS3231 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_DS3231 : RTC_I2C {
+class RTC_DS3231 : pubic RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -403,7 +403,7 @@ public:
     @brief  RTC based on the PCF8523 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8523 : RTC_I2C {
+class RTC_PCF8523 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   void adjust(const DateTime &dt);
@@ -430,7 +430,7 @@ public:
     @brief  RTC based on the PCF8563 chip connected via I2C and the Wire library
 */
 /**************************************************************************/
-class RTC_PCF8563 : RTC_I2C {
+class RTC_PCF8563 : public RTC_I2C {
 public:
   bool begin(TwoWire *wireInstance = &Wire);
   bool lostPower(void);


### PR DESCRIPTION
- Scope:
- Class definitions of RTC_DS1307; RTC_DS3231; RTC_PCF8523; RTC_PF8563, added 'public' for the RTC_I2C base class. This gives the methods in 'protected' access in any inherited classes. This allows child classes access to RTC_I2C methods such as bcd2bin(); bin2bdc(); read_register(); and write_register().

In RTC_DS3231.cpp, removed the check for INTCN bit in the control register, as setting an alarm is not dependent on the INTCN bit being set. The bits A1F and A2F are set when the alarm is triggered, regardless of the INTCN bit state. This allows setting alarms without needing to enable the interrupt control bit as the user may be using the SQW signal on that pin (e.g. 1 Hz).

- imitations: - None -

- Tests:
- Ran tests on RTC_DS3231 class against several DS3231 & DS3232 modules including a DS3231M. The changes do not impact the functionality and the alarms times were successfully set.  Using the RTC_I2C::read_register() method, I was able to read the registers and extract the required information for the Binary Clock project.
