### PR TITLE
Added getAlarmedState() function

### DIFF
--- a/src/RTC_DS3231.cpp
+++ b/src/RTC_DS3231.cpp
@@ -351,6 +351,19 @@ bool RTC_DS3231::alarmFired(uint8_t alarm_num) {
 
 /**************************************************************************/
 /*!
+    @brief  Get the state of the alarm interrupt flag
+        @param 	alarm_num Alarm number
+    @return False if interrupt flag is not set, otherwise true
+*/
+/**************************************************************************/
+bool RTC_DS3231::getAlarmedState(uint8_t alarm_num){
+  uint8_t alarmedState = read_register(DS3231_CONTROL);
+  alarmedState &= (1 << (alarm_num - 1));
+  return alarmedState;
+}
+
+/**************************************************************************/
+/*!
     @brief  Enable 32KHz Output
     @details The 32kHz output is enabled by default. It requires an external
     pull-up resistor to function correctly

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -384,6 +384,7 @@ public:
   void disableAlarm(uint8_t alarm_num);
   void clearAlarm(uint8_t alarm_num);
   bool alarmFired(uint8_t alarm_num);
+  bool getAlarmedState(uint8_t alarm_num);
   void enable32K(void);
   void disable32K(void);
   bool isEnabled32K(void);


### PR DESCRIPTION
Adds a function that checks the interrupt flag of either of the two alarms on the DS3231. The name of the function could maybe be better, but other than that i haven't touched anything other than adding this function, so everything else should still work as normal, my change only adds a little bit of functionality to the library.

I needed this function to control an indicator LED that indicates to the user whether the alarm is active or not (indicating whether the alarm will go off at the alarm time or not).